### PR TITLE
fix(report-service): stabilize mvn test baseline

### DIFF
--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recon-report-service/src/test/resources/application.properties
+++ b/recon-report-service/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Test-scoped overrides for `mvn test` baseline.
+# Production properties under src/main/resources/application.properties depend on
+# env vars (APP_PORT, EUREKA_SERVICE_NAME, MYSQL_SERVICE_NAME) that are not set
+# during a plain `mvn test`, which breaks @SpringBootTest context loading.
+# These overrides keep the context self-contained: random port, no Eureka,
+# in-memory H2 instead of MySQL.
+
+spring.application.name=report-service
+
+# Random free port avoids unresolved ${APP_PORT} placeholder.
+server.port=0
+
+# Don't try to register with / fetch from a Eureka registry during tests.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+
+# In-memory H2 in MySQL-compat mode so JPA auto-config can stand up an
+# EntityManagerFactory without a running MySQL server.
+spring.datasource.url=jdbc:h2:mem:reportdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Use the production Hibernate dialect so Spring Data JPA's startup validation
+# of @Query JPQL recognizes MySQL HQL functions (e.g. DATE_FORMAT, YEAR, MONTH).
+# H2 only serves the underlying JDBC connection; no actual SQL is executed by
+# the contextLoads baseline test, so dialect/database mismatch is harmless here.
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+
+# Skip schema generation so Hibernate doesn't try to apply MySQL DDL to H2.
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- Stabilizes report-service test baseline and test properties so later feature PRs have reliable CI footing.
- This PR is part of an ordered stack for the rating/finalization/retort/school visibility rollout.

## Review Order
- Review this after: none (start here)

## Test plan
- [ ] Checkout this branch
- [ ] Run the service-level tests relevant to changed modules
- [ ] Verify behavior described in summary

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test-scoped configuration and a test-only dependency to make `mvn test` self-contained, without affecting production runtime behavior.
> 
> **Overview**
> Makes `recon-report-service`’s `mvn test` baseline reliably load the Spring context by adding test-scoped `H2` and introducing `src/test/resources/application.properties` overrides.
> 
> Tests now run with a random port, Eureka/discovery disabled, and an in-memory H2 datasource (MySQL mode) while skipping schema generation and keeping the MySQL Hibernate dialect for query validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646470d03f97755a3b23104778ac669d660f1380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->