### PR TITLE
feat(report-service): add report finalization metadata defaults

### DIFF
--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
@@ -1,6 +1,7 @@
 package com.idea.recon.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
@@ -20,6 +21,8 @@ public class ReportDTO {
 	private LocalDate submissionDate; // ALWAYS GOTTEN FROM BACKEND
 	private LocalDate weekStartDate; // Start and End can be gotten from a single given date.
 	private LocalDate weekEndDate; // Might remove these in favor of just a single date
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	
 	// Not going to use entities because users should be contained
 	// in user-service

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -1,6 +1,7 @@
 package com.idea.recon.entity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -38,6 +39,8 @@ public class Report {
 	
 	private Integer contractorLinkId;
 	private Integer traineeLinkId;
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),
@@ -65,6 +68,8 @@ public class Report {
 				.submissionDate(submissionDate)
 				.weekStartDate(weekStartDate)
 				.weekEndDate(weekEndDate)
+				.isFinalized(isFinalized)
+				.finalizedAt(finalizedAt)
 				.sentByEmail(sentBy)
 				.sentForEmail(sentFor)
 				.build();

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -83,6 +83,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
@@ -117,6 +119,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(report.getTitle())
 				.build();
@@ -143,6 +147,8 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(endOfWeek)
 				.contractorLinkId(response.getBody().getById())
 				.traineeLinkId(response.getBody().getForId())
+				.isFinalized(false)
+				.finalizedAt(null)
 				.build();
 		
 		report = reportRepository.save(report);

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.idea.recon.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.idea.recon.dto.RelationshipVerificationDTO;
+import com.idea.recon.dto.ReportDTO;
+import com.idea.recon.entity.Report;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.utility.MicroserviceUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	@Mock
+	private MicroserviceUtil microserviceUtil;
+
+	@Mock
+	private ReportRepository reportRepository;
+
+	@InjectMocks
+	private ReportServiceImpl reportService;
+
+	@Test
+	void createReportDefaultsToDraftStateForContractorSubmission() throws Exception {
+		RelationshipVerificationDTO relationship = RelationshipVerificationDTO.builder()
+				.byId(10)
+				.forId(20)
+				.byName("Contractor Name")
+				.forName("Trainee Name")
+				.byEmail("contractor@example.com")
+				.forEmail("trainee@example.com")
+				.build();
+
+		ReportDTO reportDTO = ReportDTO.builder()
+				.title("Weekly Report")
+				.description("Progress update")
+				.grade("A")
+				.sentByEmail("contractor@example.com")
+				.sentForEmail("trainee@example.com")
+				.weekStartDate(LocalDate.of(2026, 5, 4))
+				.weekEndDate(LocalDate.of(2026, 5, 10))
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.contractorReportExist(eq(10), eq(20), eq(LocalDate.of(2026, 5, 4)),
+				eq(LocalDate.of(2026, 5, 10)))).thenReturn(false);
+		when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+			Report report = invocation.getArgument(0);
+			report.setReportId(99);
+			return report;
+		});
+		when(restTemplate.exchange(contains("/email/report-created"), eq(HttpMethod.POST), any(HttpEntity.class),
+				eq(String.class))).thenReturn(ResponseEntity.ok("ok"));
+
+		String result = reportService.createReport(reportDTO, "token");
+
+		ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+		verify(reportRepository).save(reportCaptor.capture());
+		Report savedReport = reportCaptor.getValue();
+
+		assertEquals("Report Created.", result);
+		assertFalse(savedReport.getIsFinalized());
+		assertNull(savedReport.getFinalizedAt());
+	}
+
+	@Test
+	void toReportDtoIncludesFinalizationMetadata() {
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 12, 30);
+		Report report = Report.builder()
+				.reportId(7)
+				.title("Title")
+				.description("Body")
+				.grade(Grade.A)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build();
+
+		ReportDTO dto = report.toReportDTO("contractor@example.com", "trainee@example.com");
+
+		assertTrue(dto.getIsFinalized());
+		assertEquals(finalizedAt, dto.getFinalizedAt());
+	}
+}

--- a/recon-report-service/src/test/resources/application.properties
+++ b/recon-report-service/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Test-scoped overrides for `mvn test` baseline.
+# Production properties under src/main/resources/application.properties depend on
+# env vars (APP_PORT, EUREKA_SERVICE_NAME, MYSQL_SERVICE_NAME) that are not set
+# during a plain `mvn test`, which breaks @SpringBootTest context loading.
+# These overrides keep the context self-contained: random port, no Eureka,
+# in-memory H2 instead of MySQL.
+
+spring.application.name=report-service
+
+# Random free port avoids unresolved ${APP_PORT} placeholder.
+server.port=0
+
+# Don't try to register with / fetch from a Eureka registry during tests.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+
+# In-memory H2 in MySQL-compat mode so JPA auto-config can stand up an
+# EntityManagerFactory without a running MySQL server.
+spring.datasource.url=jdbc:h2:mem:reportdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Use the production Hibernate dialect so Spring Data JPA's startup validation
+# of @Query JPQL recognizes MySQL HQL functions (e.g. DATE_FORMAT, YEAR, MONTH).
+# H2 only serves the underlying JDBC connection; no actual SQL is executed by
+# the contextLoads baseline test, so dialect/database mismatch is harmless here.
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+
+# Skip schema generation so Hibernate doesn't try to apply MySQL DDL to H2.
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- Adds report finalization metadata defaults and service wiring to persist/read finalized state.
- This PR is part of an ordered stack for the rating/finalization/retort/school visibility rollout.

## Review Order
- Review this after: PR #1

## Test plan
- [ ] Checkout this branch
- [ ] Run the service-level tests relevant to changed modules
- [ ] Verify behavior described in summary

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted fields (`isFinalized`, `finalizedAt`) on `Report`, which likely requires a DB schema migration and could affect existing reads/writes if not deployed in sync. Test configuration changes (H2 + disabled Eureka) are low risk but may mask MySQL-specific issues.
> 
> **Overview**
> Reports now carry **finalization metadata**: `Report`/`ReportDTO` add `isFinalized` and `finalizedAt`, and these values are included when converting entities to DTOs and when returning data from `getReport`/`updateReport`.
> 
> New reports are created in a **draft state** (`isFinalized=false`, `finalizedAt=null`) and this behavior is covered by new unit tests.
> 
> Test setup is hardened by adding a test-scoped `h2` dependency and `src/test/resources/application.properties` overrides to disable Eureka, avoid `${APP_PORT}` placeholders, and use an in-memory datasource for `mvn test`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f983fab07c7915cf3a2ff4a45cbb63f3ba5dd4c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->