### PR TITLE
feat(retort): introduce one-to-one retort entity for reports

### DIFF
--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
@@ -1,6 +1,7 @@
 package com.idea.recon.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
@@ -20,6 +21,8 @@ public class ReportDTO {
 	private LocalDate submissionDate; // ALWAYS GOTTEN FROM BACKEND
 	private LocalDate weekStartDate; // Start and End can be gotten from a single given date.
 	private LocalDate weekEndDate; // Might remove these in favor of just a single date
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	
 	// Not going to use entities because users should be contained
 	// in user-service

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -3,12 +3,15 @@ package com.idea.recon.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.enums.Grade;
@@ -41,6 +44,9 @@ public class Report {
 	private Integer traineeLinkId;
 	private Boolean isFinalized;
 	private LocalDateTime finalizedAt;
+
+	@OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private Retort retort;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -1,6 +1,7 @@
 package com.idea.recon.entity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -38,6 +39,8 @@ public class Report {
 	
 	private Integer contractorLinkId;
 	private Integer traineeLinkId;
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),
@@ -65,6 +68,8 @@ public class Report {
 				.submissionDate(submissionDate)
 				.weekStartDate(weekStartDate)
 				.weekEndDate(weekEndDate)
+				.isFinalized(isFinalized)
+				.finalizedAt(finalizedAt)
 				.sentByEmail(sentBy)
 				.sentForEmail(sentFor)
 				.build();

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
@@ -1,0 +1,40 @@
+package com.idea.recon.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "retort")
+public class Retort {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer retortId;
+
+	/** Trainee / junior contractor authoring the retort (minimal FK-style reference). */
+	private Integer traineeAuthorId;
+
+	private String content;
+
+	private LocalDateTime createdAt;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "report_id", unique = true, nullable = false)
+	private Report report;
+}

--- a/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
@@ -1,0 +1,12 @@
+package com.idea.recon.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.idea.recon.entity.Retort;
+
+public interface RetortRepository extends JpaRepository<Retort, Integer> {
+
+	Optional<Retort> findByReport_ReportId(Integer reportId);
+}

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -83,6 +83,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
@@ -117,6 +119,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(report.getTitle())
 				.build();
@@ -143,6 +147,8 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(endOfWeek)
 				.contractorLinkId(response.getBody().getById())
 				.traineeLinkId(response.getBody().getForId())
+				.isFinalized(false)
+				.finalizedAt(null)
 				.build();
 		
 		report = reportRepository.save(report);

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.idea.recon.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.idea.recon.entity.Report;
+import com.idea.recon.entity.Retort;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.repository.RetortRepository;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+		"spring.jpa.hibernate.ddl-auto=create-drop",
+})
+class ReportRetortVisibilityIntegrationTest {
+
+	@Autowired
+	private ReportRepository reportRepository;
+
+	@Autowired
+	private RetortRepository retortRepository;
+
+	@Test
+	void reportAllowsAtMostOneRetort_enforcedByDatabase() {
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 15, 0);
+
+		Report finalizedReport = reportRepository.save(Report.builder()
+				.title("Weekly")
+				.description("Work done")
+				.grade(Grade.B)
+				.submissionDate(LocalDate.of(2026, 5, 7))
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.contractorLinkId(100)
+				.traineeLinkId(200)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build());
+
+		Retort first = Retort.builder()
+				.traineeAuthorId(555)
+				.content("Junior feedback")
+				.createdAt(LocalDateTime.of(2026, 5, 7, 16, 0))
+				.report(finalizedReport)
+				.build();
+
+		retortRepository.save(first);
+		retortRepository.flush();
+
+		assertThat(retortRepository.findByReport_ReportId(finalizedReport.getReportId())).isPresent();
+
+		Retort duplicateRetort = Retort.builder()
+				.traineeAuthorId(556)
+				.content("Attempted second retort")
+				.createdAt(LocalDateTime.of(2026, 5, 8, 10, 0))
+				.report(finalizedReport)
+				.build();
+
+		assertThatThrownBy(() -> {
+			retortRepository.save(duplicateRetort);
+			retortRepository.flush();
+		}).isInstanceOf(DataIntegrityViolationException.class);
+	}
+}

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.idea.recon.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.idea.recon.dto.RelationshipVerificationDTO;
+import com.idea.recon.dto.ReportDTO;
+import com.idea.recon.entity.Report;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.utility.MicroserviceUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	@Mock
+	private MicroserviceUtil microserviceUtil;
+
+	@Mock
+	private ReportRepository reportRepository;
+
+	@InjectMocks
+	private ReportServiceImpl reportService;
+
+	@Test
+	void createReportDefaultsToDraftStateForContractorSubmission() throws Exception {
+		RelationshipVerificationDTO relationship = RelationshipVerificationDTO.builder()
+				.byId(10)
+				.forId(20)
+				.byName("Contractor Name")
+				.forName("Trainee Name")
+				.byEmail("contractor@example.com")
+				.forEmail("trainee@example.com")
+				.build();
+
+		ReportDTO reportDTO = ReportDTO.builder()
+				.title("Weekly Report")
+				.description("Progress update")
+				.grade("A")
+				.sentByEmail("contractor@example.com")
+				.sentForEmail("trainee@example.com")
+				.weekStartDate(LocalDate.of(2026, 5, 4))
+				.weekEndDate(LocalDate.of(2026, 5, 10))
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.contractorReportExist(eq(10), eq(20), eq(LocalDate.of(2026, 5, 4)),
+				eq(LocalDate.of(2026, 5, 10)))).thenReturn(false);
+		when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+			Report report = invocation.getArgument(0);
+			report.setReportId(99);
+			return report;
+		});
+		when(restTemplate.exchange(contains("/email/report-created"), eq(HttpMethod.POST), any(HttpEntity.class),
+				eq(String.class))).thenReturn(ResponseEntity.ok("ok"));
+
+		String result = reportService.createReport(reportDTO, "token");
+
+		ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+		verify(reportRepository).save(reportCaptor.capture());
+		Report savedReport = reportCaptor.getValue();
+
+		assertEquals("Report Created.", result);
+		assertFalse(savedReport.getIsFinalized());
+		assertNull(savedReport.getFinalizedAt());
+	}
+
+	@Test
+	void toReportDtoIncludesFinalizationMetadata() {
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 12, 30);
+		Report report = Report.builder()
+				.reportId(7)
+				.title("Title")
+				.description("Body")
+				.grade(Grade.A)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build();
+
+		ReportDTO dto = report.toReportDTO("contractor@example.com", "trainee@example.com");
+
+		assertTrue(dto.getIsFinalized());
+		assertEquals(finalizedAt, dto.getFinalizedAt());
+	}
+}

--- a/recon-report-service/src/test/resources/application.properties
+++ b/recon-report-service/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Test-scoped overrides for `mvn test` baseline.
+# Production properties under src/main/resources/application.properties depend on
+# env vars (APP_PORT, EUREKA_SERVICE_NAME, MYSQL_SERVICE_NAME) that are not set
+# during a plain `mvn test`, which breaks @SpringBootTest context loading.
+# These overrides keep the context self-contained: random port, no Eureka,
+# in-memory H2 instead of MySQL.
+
+spring.application.name=report-service
+
+# Random free port avoids unresolved ${APP_PORT} placeholder.
+server.port=0
+
+# Don't try to register with / fetch from a Eureka registry during tests.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+
+# In-memory H2 in MySQL-compat mode so JPA auto-config can stand up an
+# EntityManagerFactory without a running MySQL server.
+spring.datasource.url=jdbc:h2:mem:reportdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Use the production Hibernate dialect so Spring Data JPA's startup validation
+# of @Query JPQL recognizes MySQL HQL functions (e.g. DATE_FORMAT, YEAR, MONTH).
+# H2 only serves the underlying JDBC connection; no actual SQL is executed by
+# the contextLoads baseline test, so dialect/database mismatch is harmless here.
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+
+# Skip schema generation so Hibernate doesn't try to apply MySQL DDL to H2.
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- Introduces one-to-one Retort entity/repository and integration coverage for report-retort visibility behavior.
- This PR is part of an ordered stack for the rating/finalization/retort/school visibility rollout.

## Review Order
- Review this after: PR #2

## Test plan
- [ ] Checkout this branch
- [ ] Run the service-level tests relevant to changed modules
- [ ] Verify behavior described in summary

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new persisted one-to-one relationship (`Report`↔`Retort`) with a uniqueness constraint and updates DTO/service behavior, which can affect database schema/migrations and JPA persistence behavior.
> 
> **Overview**
> Adds report **finalization metadata** (`isFinalized`, `finalizedAt`) to `Report`/`ReportDTO`, wires it through `ReportServiceImpl` responses, and defaults new reports to a non-finalized draft state.
> 
> Introduces a new `Retort` JPA entity with a **one-to-one** link to `Report` (unique `report_id`) plus `RetortRepository` lookup by report id, and adds tests (including H2-backed `@SpringBootTest`) to enforce the single-retort-per-report constraint and to validate the new finalization fields. Also updates test infrastructure by adding H2 and test `application.properties` overrides to make `mvn test` self-contained (no Eureka/MySQL/env vars).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d656becb57832479aa6c4c2ae120478f2ebacb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->