### PR TITLE
feat(report-service): finalize, retort, and school REST layer

### DIFF
--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recon-report-service/src/main/java/com/idea/recon/controller/ContractorController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/ContractorController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.exception.ReportException;
 import com.idea.recon.service.ReportService;
@@ -76,5 +75,16 @@ public class ContractorController {
 	ResponseEntity<List<String>> getWeekRangeThatContainReports(@RequestParam(value = "by") String byEmail, @RequestParam(value = "for") String forEmail, @RequestParam(value = "year") Integer year, @RequestParam(value = "month") String month, @RequestHeader (name="Authorization") String token) throws ReportException, Exception{
 		token = token.split(" ")[1];
 		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month), HttpStatus.OK);
+	}
+
+	@PutMapping("/finalize-report")
+	ResponseEntity<ReportDTO> finalizeReport(
+			@RequestParam(value = "by") String byEmail,
+			@RequestParam(value = "for") String forEmail,
+			@RequestParam(value = "weekStart") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStartDate,
+			@RequestParam(value = "weekEnd") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekEndDate,
+			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(reportService.finalizeReport(byEmail, forEmail, token, weekStartDate, weekEndDate), HttpStatus.OK);
 	}
 }

--- a/recon-report-service/src/main/java/com/idea/recon/controller/SchoolReportController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/SchoolReportController.java
@@ -1,0 +1,80 @@
+package com.idea.recon.controller;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.idea.recon.dto.ReportDTO;
+import com.idea.recon.exception.ReportException;
+import com.idea.recon.service.ReportService;
+
+/**
+ * School users read finalized ratings for students on their roster (user-service verifies school JWT +
+ * trainee belongs to school).
+ */
+@CrossOrigin
+@RestController
+@RequestMapping("/school")
+public class SchoolReportController {
+
+	@Autowired
+	private ReportService reportService;
+
+	@GetMapping("/report/years")
+	ResponseEntity<List<String>> getYears(
+			@RequestParam(value = "by") String contractorEmail,
+			@RequestParam(value = "for") String traineeEmail,
+			@RequestHeader(name = "Authorization") String token) throws Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(
+				reportService.getSchoolPortalYearsContainingReports(contractorEmail, traineeEmail, token), HttpStatus.OK);
+	}
+
+	@GetMapping("/report/months")
+	ResponseEntity<List<String>> getMonths(
+			@RequestParam(value = "by") String contractorEmail,
+			@RequestParam(value = "for") String traineeEmail,
+			@RequestParam(value = "year") Integer year,
+			@RequestHeader(name = "Authorization") String token) throws Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(
+				reportService.getSchoolPortalMonthsContainingReports(contractorEmail, traineeEmail, token, year),
+				HttpStatus.OK);
+	}
+
+	@GetMapping("/report/weeks")
+	ResponseEntity<List<String>> getWeeks(
+			@RequestParam(value = "by") String contractorEmail,
+			@RequestParam(value = "for") String traineeEmail,
+			@RequestParam(value = "year") Integer year,
+			@RequestParam(value = "month") String month,
+			@RequestHeader(name = "Authorization") String token) throws Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(
+				reportService.getSchoolPortalWeeksContainingReports(contractorEmail, traineeEmail, token, year, month),
+				HttpStatus.OK);
+	}
+
+	@GetMapping("/get-report")
+	ResponseEntity<ReportDTO> getReport(
+			@RequestParam(value = "by") String contractorEmail,
+			@RequestParam(value = "for") String traineeEmail,
+			@RequestParam(value = "weekStart") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStartDate,
+			@RequestParam(value = "weekEnd") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekEndDate,
+			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(
+				reportService.getSchoolPortalReport(contractorEmail, traineeEmail, token, weekStartDate, weekEndDate),
+				HttpStatus.OK);
+	}
+}

--- a/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
@@ -10,11 +10,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.exception.ReportException;
 import com.idea.recon.service.ReportService;
@@ -44,6 +47,14 @@ public class TraineeController {
 			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
 		token = token.split(" ")[1];
 		return new ResponseEntity<>(reportService.getSchoolVisibleReport(byEmail, forEmail, token, weekStartDate, weekEndDate), HttpStatus.OK);
+	}
+
+	@PostMapping("/create-retort")
+	ResponseEntity<ReportDTO> createTraineeRetort(
+			@RequestBody CreateRetortDTO dto,
+			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(reportService.createTraineeRetort(dto, token), HttpStatus.CREATED);
 	}
 	
 }

--- a/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
@@ -1,9 +1,11 @@
 package com.idea.recon.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.exception.ReportException;
 import com.idea.recon.service.ReportService;
 
@@ -30,6 +33,17 @@ public class TraineeController {
 	ResponseEntity<List<String>> getMyContractorsWhoHaveReports(@RequestParam(value = "by") String byEmail, @RequestParam(value = "for") String forEmail, @RequestParam(value = "year") Integer year, @RequestParam(value = "month") String month, @RequestHeader (name="Authorization") String token) throws ReportException, Exception{
 		token = token.split(" ")[1];
 		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month, true), HttpStatus.OK);
+	}
+
+	@GetMapping("/get-report")
+	ResponseEntity<ReportDTO> getSchoolVisibleReport(
+			@RequestParam(value = "by") String byEmail,
+			@RequestParam(value = "for") String forEmail,
+			@RequestParam(value = "weekStart") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStartDate,
+			@RequestParam(value = "weekEnd") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekEndDate,
+			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(reportService.getSchoolVisibleReport(byEmail, forEmail, token, weekStartDate, weekEndDate), HttpStatus.OK);
 	}
 	
 }

--- a/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
@@ -29,7 +29,7 @@ public class TraineeController {
 	@GetMapping("/get-contractors")
 	ResponseEntity<List<String>> getMyContractorsWhoHaveReports(@RequestParam(value = "by") String byEmail, @RequestParam(value = "for") String forEmail, @RequestParam(value = "year") Integer year, @RequestParam(value = "month") String month, @RequestHeader (name="Authorization") String token) throws ReportException, Exception{
 		token = token.split(" ")[1];
-		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month), HttpStatus.OK);
+		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month, true), HttpStatus.OK);
 	}
 	
 }

--- a/recon-report-service/src/main/java/com/idea/recon/dto/CreateRetortDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/CreateRetortDTO.java
@@ -1,0 +1,23 @@
+package com.idea.recon.dto;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CreateRetortDTO {
+
+	private String content;
+
+	/** Contractor email (rating author) */
+	private String sentByEmail;
+
+	/** Trainee / junior contractor email */
+	private String sentForEmail;
+
+	private LocalDate weekStartDate;
+
+	private LocalDate weekEndDate;
+}

--- a/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
@@ -17,6 +17,8 @@ public class ReportDTO {
 	private String title;
 	private String description;
 	private String rebuttal;
+	/** Text from the optional {@code Retort} entity (distinct from legacy {@code rebuttal}). */
+	private String retortContent;
 	private String grade;
 	private LocalDate submissionDate; // ALWAYS GOTTEN FROM BACKEND
 	private LocalDate weekStartDate; // Start and End can be gotten from a single given date.

--- a/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
@@ -1,6 +1,7 @@
 package com.idea.recon.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
@@ -20,6 +21,8 @@ public class ReportDTO {
 	private LocalDate submissionDate; // ALWAYS GOTTEN FROM BACKEND
 	private LocalDate weekStartDate; // Start and End can be gotten from a single given date.
 	private LocalDate weekEndDate; // Might remove these in favor of just a single date
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	
 	// Not going to use entities because users should be contained
 	// in user-service

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -3,12 +3,15 @@ package com.idea.recon.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.enums.Grade;
@@ -41,6 +44,9 @@ public class Report {
 	private Integer traineeLinkId;
 	private Boolean isFinalized;
 	private LocalDateTime finalizedAt;
+
+	@OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private Retort retort;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -1,6 +1,7 @@
 package com.idea.recon.entity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -38,6 +39,8 @@ public class Report {
 	
 	private Integer contractorLinkId;
 	private Integer traineeLinkId;
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),
@@ -65,6 +68,8 @@ public class Report {
 				.submissionDate(submissionDate)
 				.weekStartDate(weekStartDate)
 				.weekEndDate(weekEndDate)
+				.isFinalized(isFinalized)
+				.finalizedAt(finalizedAt)
 				.sentByEmail(sentBy)
 				.sentForEmail(sentFor)
 				.build();

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -19,7 +19,9 @@ import com.idea.recon.enums.Grade;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
@@ -45,6 +47,8 @@ public class Report {
 	private Boolean isFinalized;
 	private LocalDateTime finalizedAt;
 
+	@ToString.Exclude
+	@EqualsAndHashCode.Exclude
 	@OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private Retort retort;
 	/*

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
@@ -13,7 +13,9 @@ import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
@@ -34,6 +36,8 @@ public class Retort {
 
 	private LocalDateTime createdAt;
 
+	@ToString.Exclude
+	@EqualsAndHashCode.Exclude
 	@OneToOne(optional = false)
 	@JoinColumn(name = "report_id", unique = true, nullable = false)
 	private Report report;

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
@@ -1,0 +1,40 @@
+package com.idea.recon.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "retort")
+public class Retort {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer retortId;
+
+	/** Trainee / junior contractor authoring the retort (minimal FK-style reference). */
+	private Integer traineeAuthorId;
+
+	private String content;
+
+	private LocalDateTime createdAt;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "report_id", unique = true, nullable = false)
+	private Report report;
+}

--- a/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
@@ -47,6 +47,16 @@ public interface ReportRepository extends JpaRepository<Report, Integer> {
 			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year AND MONTH(week_start_date) = :month"
 	)
 	List<String> getWeeksWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year, Integer month);
+
+	/**
+	 * Same as {@link #getWeeksWithReportsOfContractorWithTrainee} but only weeks the school / trainee
+	 * may see ({@code is_finalized = true}).
+	 */
+	@Query("SELECT CONCAT(week_start_date, ' - ',  week_end_date) AS weekly_report FROM Report " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year AND MONTH(week_start_date) = :month "
+			+ "AND is_finalized = true"
+	)
+	List<String> getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year, Integer month);
 	
 }
 

--- a/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
@@ -46,11 +46,22 @@ public interface ReportRepository extends JpaRepository<Report, Integer> {
 			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId " +
 			"GROUP BY YEAR(week_start_date)")
 	List<String> getYearsWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId);
+
+	@Query("SELECT YEAR(week_start_date) AS year FROM Report " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND is_finalized = true " +
+			"GROUP BY YEAR(week_start_date)")
+	List<String> getSchoolVisibleYearsWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId);
 	
 	@Query("SELECT DATE_FORMAT(week_start_date, '%M') AS month FROM Report " +
 			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year " +
 			"GROUP BY month")
 	List<String> getMonthsWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year);
+
+	@Query("SELECT DATE_FORMAT(week_start_date, '%M') AS month FROM Report " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year "
+			+ "AND is_finalized = true "
+			+ "GROUP BY month")
+	List<String> getSchoolVisibleMonthsWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year);
 	
 	@Query("SELECT CONCAT(week_start_date, ' - ',  week_end_date) AS weekly_report FROM Report " +
 			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year AND MONTH(week_start_date) = :month"

--- a/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
@@ -31,6 +31,15 @@ public interface ReportRepository extends JpaRepository<Report, Integer> {
 		       "FROM Report r " +
 		       "WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND week_start_date = :startOfWeek AND week_end_date = :endOfWeek")
 	Optional<Report>  getSpecificReport(Integer contractorId, Integer traineeId, LocalDate startOfWeek, LocalDate endOfWeek);
+
+	/** Same lookup as {@link #getSpecificReport} but only if the row is finalized (school / trainee reads). */
+	@Query("SELECT r " +
+			"FROM Report r " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND week_start_date = :startOfWeek "
+			+ "AND week_end_date = :endOfWeek AND is_finalized = true")
+	Optional<Report> getSchoolVisibleSpecificReport(Integer contractorId, Integer traineeId, LocalDate startOfWeek,
+			LocalDate endOfWeek);
+
 	
 	
 	@Query("SELECT YEAR(week_start_date) AS year FROM Report " +

--- a/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
@@ -1,0 +1,12 @@
+package com.idea.recon.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.idea.recon.entity.Retort;
+
+public interface RetortRepository extends JpaRepository<Retort, Integer> {
+
+	Optional<Retort> findByReport_ReportId(Integer reportId);
+}

--- a/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
@@ -19,4 +19,10 @@ public interface ReportService {
 	public List<String> getMonthsContainingReports(String byEmail, String forEmail, String token, Integer year) throws ReportException, Exception;
 	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month) throws ReportException, Exception;
 
+	/**
+	 * @param finalizedOnly when true, only weeks with a finalized report are returned (school / trainee listings).
+	 *        When false, all saved reports for that relationship are included (contractor tooling).
+	 */
+	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month, boolean finalizedOnly) throws ReportException, Exception;
+
 }

--- a/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
@@ -3,6 +3,7 @@ package com.idea.recon.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.exception.ReportException;
 
@@ -24,5 +25,27 @@ public interface ReportService {
 	 *        When false, all saved reports for that relationship are included (contractor tooling).
 	 */
 	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month, boolean finalizedOnly) throws ReportException, Exception;
+
+	/** Contractor finalizes a rating for the given week (draft becomes visible to school rules). */
+	public ReportDTO finalizeReport(String byEmail, String forEmail, String token, LocalDate weekStart, LocalDate weekEnd) throws ReportException, Exception;
+
+	/**
+	 * Trainee (junior) authors the single allowed retort for a finalized report in that week.
+	 * Must be called with a trainee JWT; enforced via user-service trainee-only verify endpoint.
+	 */
+	public ReportDTO createTraineeRetort(CreateRetortDTO dto, String token) throws ReportException, Exception;
+
+	// --- School portal (school JWT; roster check in user-service) — finalized ratings only in listings ---
+
+	ReportDTO getSchoolPortalReport(String byEmail, String forEmail, String token, LocalDate weekStart, LocalDate weekEnd)
+			throws ReportException, Exception;
+
+	List<String> getSchoolPortalYearsContainingReports(String byEmail, String forEmail, String token) throws ReportException, Exception;
+
+	List<String> getSchoolPortalMonthsContainingReports(String byEmail, String forEmail, String token, Integer year)
+			throws ReportException, Exception;
+
+	List<String> getSchoolPortalWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month)
+			throws ReportException, Exception;
 
 }

--- a/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
@@ -2,17 +2,17 @@ package com.idea.recon.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
-import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
-import com.idea.recon.entity.Report;
 import com.idea.recon.exception.ReportException;
 
 public interface ReportService {
 	
 	public String createReport(ReportDTO reportDTO, String token) throws ReportException, Exception;
 	public ReportDTO getReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception;
+
+	/** Trainee / school read: same contract as {@link #getReport} but only returns a finalized report. */
+	public ReportDTO getSchoolVisibleReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception;
 	public ReportDTO updateReport(ReportDTO reportDTO, String token)throws ReportException, Exception;
 	
 	public List<String> getYearsContainingReports(String byEmail, String forEmail, String token) throws ReportException, Exception;

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -177,6 +177,12 @@ public class ReportServiceImpl implements ReportService {
 	@Override
 	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year,
 			String month) throws ReportException, Exception {
+		return getWeeksContainingReports(byEmail, forEmail, token, year, month, false);
+	}
+
+	@Override
+	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year,
+			String month, boolean finalizedOnly) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
 		
@@ -212,7 +218,12 @@ public class ReportServiceImpl implements ReportService {
 		else
 			monthInt = Integer.valueOf(month);
 		
-		return reportRepository.getWeeksWithReportsOfContractorWithTrainee(relationship.getById(), relationship.getForId(), year, monthInt);
+		if (finalizedOnly) {
+			return reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(
+					relationship.getById(), relationship.getForId(), year, monthInt);
+		}
+		return reportRepository.getWeeksWithReportsOfContractorWithTrainee(
+				relationship.getById(), relationship.getForId(), year, monthInt);
 	}
 	
 	// PRIVATE METHDOS 

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -208,38 +208,7 @@ public class ReportServiceImpl implements ReportService {
 			String month, boolean finalizedOnly) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
-		
-		Map<String, Integer> monthStringToMonthInteger = new HashMap<>();
-		monthStringToMonthInteger.put("january", 1);
-		monthStringToMonthInteger.put("jan", 1);
-		monthStringToMonthInteger.put("february", 2);
-		monthStringToMonthInteger.put("feb", 2);
-		monthStringToMonthInteger.put("march", 3);
-		monthStringToMonthInteger.put("mar", 3);
-		monthStringToMonthInteger.put("april", 4);
-		monthStringToMonthInteger.put("apr", 4);
-		monthStringToMonthInteger.put("may", 5);
-		monthStringToMonthInteger.put("june", 6);
-		monthStringToMonthInteger.put("jun", 6);
-		monthStringToMonthInteger.put("july", 7);
-		monthStringToMonthInteger.put("jul", 7);
-		monthStringToMonthInteger.put("august", 8);
-		monthStringToMonthInteger.put("aug", 8);
-		monthStringToMonthInteger.put("september", 9);
-		monthStringToMonthInteger.put("sep", 9);
-		monthStringToMonthInteger.put("october", 10);
-		monthStringToMonthInteger.put("oct", 10);
-		monthStringToMonthInteger.put("november", 11);
-		monthStringToMonthInteger.put("nov", 11);
-		monthStringToMonthInteger.put("december", 12);
-		monthStringToMonthInteger.put("dec", 12);
-		
-		int monthInt;
-		month = month.toLowerCase();
-		if (monthStringToMonthInteger.containsKey(month))
-			monthInt = monthStringToMonthInteger.get(month);
-		else
-			monthInt = Integer.valueOf(month);
+		int monthInt = parseMonthToInt(month);
 		
 		if (finalizedOnly) {
 			return reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(
@@ -347,38 +316,7 @@ public class ReportServiceImpl implements ReportService {
 			String month) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifySchoolIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
-
-		Map<String, Integer> monthStringToMonthInteger = new HashMap<>();
-		monthStringToMonthInteger.put("january", 1);
-		monthStringToMonthInteger.put("jan", 1);
-		monthStringToMonthInteger.put("february", 2);
-		monthStringToMonthInteger.put("feb", 2);
-		monthStringToMonthInteger.put("march", 3);
-		monthStringToMonthInteger.put("mar", 3);
-		monthStringToMonthInteger.put("april", 4);
-		monthStringToMonthInteger.put("apr", 4);
-		monthStringToMonthInteger.put("may", 5);
-		monthStringToMonthInteger.put("june", 6);
-		monthStringToMonthInteger.put("jun", 6);
-		monthStringToMonthInteger.put("july", 7);
-		monthStringToMonthInteger.put("jul", 7);
-		monthStringToMonthInteger.put("august", 8);
-		monthStringToMonthInteger.put("aug", 8);
-		monthStringToMonthInteger.put("september", 9);
-		monthStringToMonthInteger.put("sep", 9);
-		monthStringToMonthInteger.put("october", 10);
-		monthStringToMonthInteger.put("oct", 10);
-		monthStringToMonthInteger.put("november", 11);
-		monthStringToMonthInteger.put("nov", 11);
-		monthStringToMonthInteger.put("december", 12);
-		monthStringToMonthInteger.put("dec", 12);
-
-		int monthInt;
-		month = month.toLowerCase();
-		if (monthStringToMonthInteger.containsKey(month))
-			monthInt = monthStringToMonthInteger.get(month);
-		else
-			monthInt = Integer.valueOf(month);
+		int monthInt = parseMonthToInt(month);
 
 		return reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(
 				relationship.getById(), relationship.getForId(), year, monthInt);
@@ -444,6 +382,39 @@ public class ReportServiceImpl implements ReportService {
 					"User-service " + verificationType + " verification unavailable",
 					org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE);
 		}
+	}
+
+	private static int parseMonthToInt(String month) {
+		Map<String, Integer> monthStringToMonthInteger = new HashMap<>();
+		monthStringToMonthInteger.put("january", 1);
+		monthStringToMonthInteger.put("jan", 1);
+		monthStringToMonthInteger.put("february", 2);
+		monthStringToMonthInteger.put("feb", 2);
+		monthStringToMonthInteger.put("march", 3);
+		monthStringToMonthInteger.put("mar", 3);
+		monthStringToMonthInteger.put("april", 4);
+		monthStringToMonthInteger.put("apr", 4);
+		monthStringToMonthInteger.put("may", 5);
+		monthStringToMonthInteger.put("june", 6);
+		monthStringToMonthInteger.put("jun", 6);
+		monthStringToMonthInteger.put("july", 7);
+		monthStringToMonthInteger.put("jul", 7);
+		monthStringToMonthInteger.put("august", 8);
+		monthStringToMonthInteger.put("aug", 8);
+		monthStringToMonthInteger.put("september", 9);
+		monthStringToMonthInteger.put("sep", 9);
+		monthStringToMonthInteger.put("october", 10);
+		monthStringToMonthInteger.put("oct", 10);
+		monthStringToMonthInteger.put("november", 11);
+		monthStringToMonthInteger.put("nov", 11);
+		monthStringToMonthInteger.put("december", 12);
+		monthStringToMonthInteger.put("dec", 12);
+
+		String normalizedMonth = month.toLowerCase();
+		if (monthStringToMonthInteger.containsKey(normalizedMonth)) {
+			return monthStringToMonthInteger.get(normalizedMonth);
+		}
+		return Integer.valueOf(normalizedMonth);
 	}
 
     private ResponseEntity<RelationshipVerificationDTO> verifyIdentity(String token, String sentByEmail, String sentForEmail) throws MicroserviceException {

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -1,8 +1,8 @@
 package com.idea.recon.service.impl;
 
-import java.io.IOException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,25 +17,21 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.idea.recon.dto.ContractorAndTraineeCorrespondenceDTO;
+import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.entity.Report;
+import com.idea.recon.entity.Retort;
 import com.idea.recon.enums.Grade;
 import com.idea.recon.exception.MicroserviceException;
 import com.idea.recon.exception.ReportException;
 import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.repository.RetortRepository;
 import com.idea.recon.service.ReportService;
-import com.idea.recon.utility.ErrorInfo;
 import com.idea.recon.utility.MicroserviceUtil;
 
 
@@ -52,6 +48,9 @@ public class ReportServiceImpl implements ReportService {
 	
 	@Autowired
 	ReportRepository reportRepository;
+
+	@Autowired
+	RetortRepository retortRepository;
 	
 	@Override
 	public ReportDTO getReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
@@ -97,11 +96,14 @@ public class ReportServiceImpl implements ReportService {
 	private static ReportDTO toReadReportDto(Report report) {
 		String rebuttal = report.getRebuttal() == null ? "" : report.getRebuttal();
 		String title = report.getTitle() == null ? "" : report.getTitle();
+		Retort retort = report.getRetort();
+		String retortContent = retort != null ? retort.getContent() : null;
 		return ReportDTO.builder()
 				.reportId(report.getReportId())
 				.description(report.getDescription())
 				.grade(Grade.toString(report.getGrade()))
 				.rebuttal(rebuttal)
+				.retortContent(retortContent)
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
@@ -246,7 +248,142 @@ public class ReportServiceImpl implements ReportService {
 		return reportRepository.getWeeksWithReportsOfContractorWithTrainee(
 				relationship.getById(), relationship.getForId(), year, monthInt);
 	}
-	
+
+	@Override
+	@Transactional
+	public ReportDTO finalizeReport(String byEmail, String forEmail, String token, LocalDate weekStart, LocalDate weekEnd)
+			throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		validateWeekDateParams(weekStart, weekEnd);
+
+		Optional<Report> optionalReport =
+				reportRepository.getSpecificReport(relationship.getById(), relationship.getForId(), weekStart, weekEnd);
+		if (optionalReport.isEmpty()) {
+			throw new ReportException("Report.NOT_FOUND");
+		}
+		Report report = optionalReport.get();
+		if (Boolean.TRUE.equals(report.getIsFinalized())) {
+			return toReadReportDto(report);
+		}
+		report.setIsFinalized(true);
+		report.setFinalizedAt(LocalDateTime.now());
+		report = reportRepository.save(report);
+		return toReadReportDto(report);
+	}
+
+	@Override
+	@Transactional
+	public ReportDTO createTraineeRetort(CreateRetortDTO dto, String token) throws ReportException, Exception {
+		if (dto.getContent() == null || dto.getContent().isBlank()) {
+			throw new ReportException("Report.RETORT_CONTENT_REQUIRED");
+		}
+		ResponseEntity<RelationshipVerificationDTO> response =
+				verifyTraineeIdentity(token, dto.getSentByEmail(), dto.getSentForEmail());
+		RelationshipVerificationDTO relationship = response.getBody();
+
+		LocalDate startOfWeek = dto.getWeekStartDate() != null ? getStartOfWeek(dto.getWeekStartDate()) : getStartOfWeek(LocalDate.now());
+		LocalDate endOfWeek = dto.getWeekEndDate() != null ? getEndOfWeek(dto.getWeekEndDate()) : getEndOfWeek(LocalDate.now());
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
+		Report report = reportRepository
+				.getSpecificReport(relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek)
+				.orElseThrow(() -> new ReportException("Report.NOT_FOUND"));
+
+		if (!Boolean.TRUE.equals(report.getIsFinalized())) {
+			throw new ReportException("Report.NOT_FINALIZED");
+		}
+		if (retortRepository.findByReport_ReportId(report.getReportId()).isPresent()) {
+			throw new ReportException("Report.RETORT_EXISTS");
+		}
+
+		Retort retort = Retort.builder()
+				.traineeAuthorId(relationship.getForId())
+				.content(dto.getContent().trim())
+				.createdAt(LocalDateTime.now())
+				.report(report)
+				.build();
+		retortRepository.save(retort);
+
+		return toReadReportDto(reportRepository.findById(report.getReportId()).orElseThrow());
+	}
+
+	@Override
+	public ReportDTO getSchoolPortalReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek)
+			throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifySchoolIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
+		Optional<Report> optionalReport = reportRepository.getSchoolVisibleSpecificReport(
+				relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek);
+
+		if (optionalReport.isEmpty())
+			throw new Exception("No Report found for given date range: " + startOfWeek + " - " + endOfWeek);
+
+		return toReadReportDto(optionalReport.get());
+	}
+
+	@Override
+	public List<String> getSchoolPortalYearsContainingReports(String byEmail, String forEmail, String token)
+			throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifySchoolIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		return reportRepository.getSchoolVisibleYearsWithReportsOfContractorWithTrainee(
+				relationship.getById(), relationship.getForId());
+	}
+
+	@Override
+	public List<String> getSchoolPortalMonthsContainingReports(String byEmail, String forEmail, String token, Integer year)
+			throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifySchoolIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		return reportRepository.getSchoolVisibleMonthsWithReportsOfContractorWithTrainee(
+				relationship.getById(), relationship.getForId(), year);
+	}
+
+	@Override
+	public List<String> getSchoolPortalWeeksContainingReports(String byEmail, String forEmail, String token, Integer year,
+			String month) throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifySchoolIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+
+		Map<String, Integer> monthStringToMonthInteger = new HashMap<>();
+		monthStringToMonthInteger.put("january", 1);
+		monthStringToMonthInteger.put("jan", 1);
+		monthStringToMonthInteger.put("february", 2);
+		monthStringToMonthInteger.put("feb", 2);
+		monthStringToMonthInteger.put("march", 3);
+		monthStringToMonthInteger.put("mar", 3);
+		monthStringToMonthInteger.put("april", 4);
+		monthStringToMonthInteger.put("apr", 4);
+		monthStringToMonthInteger.put("may", 5);
+		monthStringToMonthInteger.put("june", 6);
+		monthStringToMonthInteger.put("jun", 6);
+		monthStringToMonthInteger.put("july", 7);
+		monthStringToMonthInteger.put("jul", 7);
+		monthStringToMonthInteger.put("august", 8);
+		monthStringToMonthInteger.put("aug", 8);
+		monthStringToMonthInteger.put("september", 9);
+		monthStringToMonthInteger.put("sep", 9);
+		monthStringToMonthInteger.put("october", 10);
+		monthStringToMonthInteger.put("oct", 10);
+		monthStringToMonthInteger.put("november", 11);
+		monthStringToMonthInteger.put("nov", 11);
+		monthStringToMonthInteger.put("december", 12);
+		monthStringToMonthInteger.put("dec", 12);
+
+		int monthInt;
+		month = month.toLowerCase();
+		if (monthStringToMonthInteger.containsKey(month))
+			monthInt = monthStringToMonthInteger.get(month);
+		else
+			monthInt = Integer.valueOf(month);
+
+		return reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(
+				relationship.getById(), relationship.getForId(), year, monthInt);
+	}
+
 	// PRIVATE METHDOS 
 	private static LocalDate getStartOfWeek(LocalDate date) {
         DayOfWeek dayOfWeek = date.getDayOfWeek();
@@ -260,6 +397,44 @@ public class ReportServiceImpl implements ReportService {
         return date.plusDays(daysToAdd);
     }
     
+	private ResponseEntity<RelationshipVerificationDTO> verifySchoolIdentity(
+			String token, String contractorEmail, String traineeEmail) throws MicroserviceException {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + token);
+
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		String url =
+				"http://user-service/verify/school/contractor-to-trainee?by=" + contractorEmail + "&for=" + traineeEmail;
+		ResponseEntity<RelationshipVerificationDTO> response = null;
+		try {
+			response = restTemplate.exchange(url, HttpMethod.GET, entity, RelationshipVerificationDTO.class);
+			logger.info("school verify: " + response.getBody());
+		} catch (Exception ex) {
+			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
+			logger.info("school verify error: " + ex.getClass());
+		}
+		return response;
+	}
+
+	private ResponseEntity<RelationshipVerificationDTO> verifyTraineeIdentity(
+			String token, String contractorEmail, String traineeEmail) throws MicroserviceException {
+		HttpHeaders headers = new HttpHeaders();
+		headers.set("Authorization", "Bearer " + token);
+
+		HttpEntity<String> entity = new HttpEntity<>(headers);
+		String url =
+				"http://user-service/verify/trainee/contractor-to-trainee?by=" + contractorEmail + "&for=" + traineeEmail;
+		ResponseEntity<RelationshipVerificationDTO> response = null;
+		try {
+			response = restTemplate.exchange(url, HttpMethod.GET, entity, RelationshipVerificationDTO.class);
+			logger.info("trainee verify: " + response.getBody());
+		} catch (Exception ex) {
+			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
+			logger.info("trainee verify error: " + ex.getClass());
+		}
+		return response;
+	}
+
     private ResponseEntity<RelationshipVerificationDTO> verifyIdentity(String token, String sentByEmail, String sentForEmail) throws MicroserviceException {
     	HttpHeaders headers = new HttpHeaders();
 		headers.set("Authorization", "Bearer " + token);

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -83,6 +83,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
@@ -117,6 +119,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(report.getTitle())
 				.build();
@@ -143,6 +147,8 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(endOfWeek)
 				.contractorLinkId(response.getBody().getById())
 				.traineeLinkId(response.getBody().getForId())
+				.isFinalized(false)
+				.finalizedAt(null)
 				.build();
 		
 		report = reportRepository.save(report);

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -57,24 +57,46 @@ public class ReportServiceImpl implements ReportService {
 	public ReportDTO getReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
-		
-		String regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
-		
-		if (!Pattern.matches(regex, startOfWeek.toString()) || !Pattern.matches(regex, endOfWeek.toString()))
-			throw new Exception("incorrect start or end date");
-		
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
 		Optional<Report> optionalReport = reportRepository.getSpecificReport(relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek);
 		logger.info(optionalReport.toString());
-		
+
 		if (optionalReport.isEmpty())
 			throw new Exception("No Report found for given date range: " + startOfWeek + " - " + endOfWeek);
-		
+
 		Report report = optionalReport.get();
-		logger.info(report.toString()); 
-		
+		logger.info(report.toString());
+		return toReadReportDto(report);
+	}
+
+	@Override
+	public ReportDTO getSchoolVisibleReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
+		Optional<Report> optionalReport = reportRepository.getSchoolVisibleSpecificReport(
+				relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek);
+		logger.info(optionalReport.toString());
+
+		if (optionalReport.isEmpty())
+			throw new Exception("No Report found for given date range: " + startOfWeek + " - " + endOfWeek);
+
+		Report report = optionalReport.get();
+		logger.info(report.toString());
+		return toReadReportDto(report);
+	}
+
+	private static void validateWeekDateParams(LocalDate startOfWeek, LocalDate endOfWeek) throws Exception {
+		String regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+		if (!Pattern.matches(regex, startOfWeek.toString()) || !Pattern.matches(regex, endOfWeek.toString()))
+			throw new Exception("incorrect start or end date");
+	}
+
+	private static ReportDTO toReadReportDto(Report report) {
 		String rebuttal = report.getRebuttal() == null ? "" : report.getRebuttal();
 		String title = report.getTitle() == null ? "" : report.getTitle();
-		
 		return ReportDTO.builder()
 				.reportId(report.getReportId())
 				.description(report.getDescription())
@@ -85,7 +107,6 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(report.getWeekEndDate())
 				.isFinalized(report.getIsFinalized())
 				.finalizedAt(report.getFinalizedAt())
-				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
 	}

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -71,7 +71,7 @@ public class ReportServiceImpl implements ReportService {
 
 	@Override
 	public ReportDTO getSchoolVisibleReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
-		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
+		ResponseEntity<RelationshipVerificationDTO> response = verifyTraineeIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
 		validateWeekDateParams(startOfWeek, endOfWeek);
 
@@ -413,6 +413,7 @@ public class ReportServiceImpl implements ReportService {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
 			logger.info("school verify error: " + ex.getClass());
 		}
+		ensureVerificationResponse(response, "school");
 		return response;
 	}
 
@@ -432,7 +433,17 @@ public class ReportServiceImpl implements ReportService {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
 			logger.info("trainee verify error: " + ex.getClass());
 		}
+		ensureVerificationResponse(response, "trainee");
 		return response;
+	}
+
+	private static void ensureVerificationResponse(
+			ResponseEntity<RelationshipVerificationDTO> response, String verificationType) throws MicroserviceException {
+		if (response == null || response.getBody() == null) {
+			throw new MicroserviceException(
+					"User-service " + verificationType + " verification unavailable",
+					org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE);
+		}
 	}
 
     private ResponseEntity<RelationshipVerificationDTO> verifyIdentity(String token, String sentByEmail, String sentForEmail) throws MicroserviceException {

--- a/recon-report-service/src/main/resources/application.properties
+++ b/recon-report-service/src/main/resources/application.properties
@@ -4,6 +4,9 @@ eureka.client.service-url.defaultZone=http://${EUREKA_SERVICE_NAME}:8761/eureka
 # Error Mapping
 Report.NOT_FOUND = The Report was not found.
 Report.Contractor.DUPLICATE_REPORT = A Report for this week already Exists. If you would like to modify this report, please follow the proper channels.
+Report.NOT_FINALIZED = The report must be finalized before a junior contractor can add a retort.
+Report.RETORT_EXISTS = A retort already exists for this report.
+Report.RETORT_CONTENT_REQUIRED = Retort content is required.
 
 #Clint info
 server.port=${APP_PORT}

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -67,12 +67,22 @@ class ReportRetortVisibilityIntegrationTest {
 		assertThat(contractorWeeks).isNotEmpty();
 		assertThat(schoolWeeks).isEmpty();
 
+		assertThat(reportRepository.getSpecificReport(contractorId, traineeId, weekStart, weekEnd)).isPresent();
+		assertThat(reportRepository.getSchoolVisibleSpecificReport(contractorId, traineeId, weekStart, weekEnd)).isEmpty();
+
 		draft.setIsFinalized(true);
 		draft.setFinalizedAt(LocalDateTime.of(2026, 6, 7, 9, 0));
 		reportRepository.saveAndFlush(draft);
 
 		schoolWeeks = reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
 		assertThat(schoolWeeks).containsExactlyInAnyOrderElementsOf(contractorWeeks);
+
+		assertThat(reportRepository.getSchoolVisibleSpecificReport(contractorId, traineeId, weekStart, weekEnd))
+				.isPresent()
+				.hasValueSatisfying(r -> {
+					assertThat(r.getReportId()).isEqualTo(draft.getReportId());
+					assertThat(r.getIsFinalized()).isTrue();
+				});
 
 		Report finalized = reportRepository.findById(draft.getReportId()).orElseThrow();
 

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.idea.recon.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.idea.recon.entity.Report;
+import com.idea.recon.entity.Retort;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.repository.RetortRepository;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+		"spring.jpa.hibernate.ddl-auto=create-drop",
+})
+class ReportRetortVisibilityIntegrationTest {
+
+	@Autowired
+	private ReportRepository reportRepository;
+
+	@Autowired
+	private RetortRepository retortRepository;
+
+	@Test
+	void reportAllowsAtMostOneRetort_enforcedByDatabase() {
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 15, 0);
+
+		Report finalizedReport = reportRepository.save(Report.builder()
+				.title("Weekly")
+				.description("Work done")
+				.grade(Grade.B)
+				.submissionDate(LocalDate.of(2026, 5, 7))
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.contractorLinkId(100)
+				.traineeLinkId(200)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build());
+
+		Retort first = Retort.builder()
+				.traineeAuthorId(555)
+				.content("Junior feedback")
+				.createdAt(LocalDateTime.of(2026, 5, 7, 16, 0))
+				.report(finalizedReport)
+				.build();
+
+		retortRepository.save(first);
+		retortRepository.flush();
+
+		assertThat(retortRepository.findByReport_ReportId(finalizedReport.getReportId())).isPresent();
+
+		Retort duplicateRetort = Retort.builder()
+				.traineeAuthorId(556)
+				.content("Attempted second retort")
+				.createdAt(LocalDateTime.of(2026, 5, 8, 10, 0))
+				.report(finalizedReport)
+				.build();
+
+		assertThatThrownBy(() -> {
+			retortRepository.save(duplicateRetort);
+			retortRepository.flush();
+		}).isInstanceOf(DataIntegrityViolationException.class);
+	}
+}

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,61 @@ class ReportRetortVisibilityIntegrationTest {
 
 	@Autowired
 	private RetortRepository retortRepository;
+
+	@Test
+	void contractorDraft_schoolListingExcludesUntilFinalized_juniorCanAddRetort() {
+		Integer contractorId = 301;
+		Integer traineeId = 401;
+		LocalDate weekStart = LocalDate.of(2026, 6, 1);
+		LocalDate weekEnd = LocalDate.of(2026, 6, 7);
+
+		Report draft = reportRepository.save(Report.builder()
+				.title("Draft weekly")
+				.description("Saved by contractor")
+				.grade(Grade.B)
+				.submissionDate(LocalDate.of(2026, 6, 7))
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.contractorLinkId(contractorId)
+				.traineeLinkId(traineeId)
+				.isFinalized(false)
+				.finalizedAt(null)
+				.build());
+
+		assertThat(draft.getReportId()).isNotNull();
+		assertThat(draft.getIsFinalized()).isFalse();
+
+		int year = 2026;
+		int month = 6;
+
+		List<String> contractorWeeks =
+				reportRepository.getWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+		List<String> schoolWeeks =
+				reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+
+		assertThat(contractorWeeks).isNotEmpty();
+		assertThat(schoolWeeks).isEmpty();
+
+		draft.setIsFinalized(true);
+		draft.setFinalizedAt(LocalDateTime.of(2026, 6, 7, 9, 0));
+		reportRepository.saveAndFlush(draft);
+
+		schoolWeeks = reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+		assertThat(schoolWeeks).containsExactlyInAnyOrderElementsOf(contractorWeeks);
+
+		Report finalized = reportRepository.findById(draft.getReportId()).orElseThrow();
+
+		retortRepository.save(Retort.builder()
+				.traineeAuthorId(902)
+				.content("Junior retort after finalize")
+				.createdAt(LocalDateTime.of(2026, 6, 7, 10, 30))
+				.report(finalized)
+				.build());
+		retortRepository.flush();
+
+		assertThat(retortRepository.findByReport_ReportId(finalized.getReportId()))
+				.hasValueSatisfying(r -> assertThat(r.getContent()).isEqualTo("Junior retort after finalize"));
+	}
 
 	@Test
 	void reportAllowsAtMostOneRetort_enforcedByDatabase() {

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -3,6 +3,7 @@ package com.idea.recon.service.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,11 +26,15 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
+import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.entity.Report;
+import com.idea.recon.entity.Retort;
 import com.idea.recon.enums.Grade;
+import com.idea.recon.exception.ReportException;
 import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.repository.RetortRepository;
 import com.idea.recon.utility.MicroserviceUtil;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +48,9 @@ class ReportServiceImplTest {
 
 	@Mock
 	private ReportRepository reportRepository;
+
+	@Mock
+	private RetortRepository retortRepository;
 
 	@InjectMocks
 	private ReportServiceImpl reportService;
@@ -106,5 +115,124 @@ class ReportServiceImplTest {
 
 		assertTrue(dto.getIsFinalized());
 		assertEquals(finalizedAt, dto.getFinalizedAt());
+	}
+
+	@Test
+	void finalizeReport_setsFinalizedFlags() throws Exception {
+		RelationshipVerificationDTO relationship = RelationshipVerificationDTO.builder()
+				.byId(10)
+				.forId(20)
+				.build();
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		Report draft = Report.builder()
+				.reportId(5)
+				.contractorLinkId(10)
+				.traineeLinkId(20)
+				.description("d")
+				.title("t")
+				.grade(Grade.B)
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.isFinalized(false)
+				.finalizedAt(null)
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))
+				.thenReturn(Optional.of(draft));
+		when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+		ReportDTO result = reportService.finalizeReport("c@x.com", "t@x.com", "jwt", weekStart, weekEnd);
+
+		ArgumentCaptor<Report> captor = ArgumentCaptor.forClass(Report.class);
+		verify(reportRepository).save(captor.capture());
+		assertTrue(captor.getValue().getIsFinalized());
+		assertTrue(result.getIsFinalized());
+		assertEquals(weekStart, result.getWeekStartDate());
+	}
+
+	@Test
+	void createTraineeRetort_requiresFinalizedReport() {
+		RelationshipVerificationDTO relationship =
+				RelationshipVerificationDTO.builder().byId(10).forId(20).build();
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		Report draft = Report.builder()
+				.reportId(8)
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.isFinalized(false)
+				.build();
+		CreateRetortDTO dto = CreateRetortDTO.builder()
+				.content("Reply")
+				.sentByEmail("c@x.com")
+				.sentForEmail("t@x.com")
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/trainee/contractor-to-trainee"), eq(HttpMethod.GET),
+				any(HttpEntity.class), eq(RelationshipVerificationDTO.class)))
+				.thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))
+				.thenReturn(Optional.of(draft));
+
+		assertThrows(ReportException.class, () -> reportService.createTraineeRetort(dto, "jwt"));
+	}
+
+	@Test
+	void createTraineeRetort_persistsWhenFinalized() throws Exception {
+		RelationshipVerificationDTO relationship =
+				RelationshipVerificationDTO.builder().byId(10).forId(20).build();
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		Report finalized = Report.builder()
+				.reportId(12)
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.isFinalized(true)
+				.finalizedAt(LocalDateTime.of(2026, 5, 5, 9, 0))
+				.description("d")
+				.title("t")
+				.grade(Grade.A)
+				.build();
+		CreateRetortDTO dto = CreateRetortDTO.builder()
+				.content("Junior reply")
+				.sentByEmail("c@x.com")
+				.sentForEmail("t@x.com")
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/trainee/contractor-to-trainee"), eq(HttpMethod.GET),
+				any(HttpEntity.class), eq(RelationshipVerificationDTO.class)))
+				.thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))
+				.thenReturn(Optional.of(finalized));
+		when(retortRepository.findByReport_ReportId(12)).thenReturn(Optional.empty());
+		when(retortRepository.save(any(Retort.class))).thenAnswer(invocation -> {
+			Retort r = invocation.getArgument(0);
+			return r;
+		});
+		Retort attached = Retort.builder().content("Junior reply").traineeAuthorId(20).report(finalized).build();
+		Report withRetort = Report.builder()
+				.reportId(12)
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.isFinalized(true)
+				.finalizedAt(finalized.getFinalizedAt())
+				.description("d")
+				.title("t")
+				.grade(Grade.A)
+				.retort(attached)
+				.build();
+		when(reportRepository.findById(12)).thenReturn(Optional.of(withRetort));
+
+		ReportDTO out = reportService.createTraineeRetort(dto, "jwt");
+
+		assertEquals("Junior reply", out.getRetortContent());
+		verify(retortRepository).save(any(Retort.class));
 	}
 }

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.idea.recon.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.idea.recon.dto.RelationshipVerificationDTO;
+import com.idea.recon.dto.ReportDTO;
+import com.idea.recon.entity.Report;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.utility.MicroserviceUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	@Mock
+	private MicroserviceUtil microserviceUtil;
+
+	@Mock
+	private ReportRepository reportRepository;
+
+	@InjectMocks
+	private ReportServiceImpl reportService;
+
+	@Test
+	void createReportDefaultsToDraftStateForContractorSubmission() throws Exception {
+		RelationshipVerificationDTO relationship = RelationshipVerificationDTO.builder()
+				.byId(10)
+				.forId(20)
+				.byName("Contractor Name")
+				.forName("Trainee Name")
+				.byEmail("contractor@example.com")
+				.forEmail("trainee@example.com")
+				.build();
+
+		ReportDTO reportDTO = ReportDTO.builder()
+				.title("Weekly Report")
+				.description("Progress update")
+				.grade("A")
+				.sentByEmail("contractor@example.com")
+				.sentForEmail("trainee@example.com")
+				.weekStartDate(LocalDate.of(2026, 5, 4))
+				.weekEndDate(LocalDate.of(2026, 5, 10))
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.contractorReportExist(eq(10), eq(20), eq(LocalDate.of(2026, 5, 4)),
+				eq(LocalDate.of(2026, 5, 10)))).thenReturn(false);
+		when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+			Report report = invocation.getArgument(0);
+			report.setReportId(99);
+			return report;
+		});
+		when(restTemplate.exchange(contains("/email/report-created"), eq(HttpMethod.POST), any(HttpEntity.class),
+				eq(String.class))).thenReturn(ResponseEntity.ok("ok"));
+
+		String result = reportService.createReport(reportDTO, "token");
+
+		ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+		verify(reportRepository).save(reportCaptor.capture());
+		Report savedReport = reportCaptor.getValue();
+
+		assertEquals("Report Created.", result);
+		assertFalse(savedReport.getIsFinalized());
+		assertNull(savedReport.getFinalizedAt());
+	}
+
+	@Test
+	void toReportDtoIncludesFinalizationMetadata() {
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 12, 30);
+		Report report = Report.builder()
+				.reportId(7)
+				.title("Title")
+				.description("Body")
+				.grade(Grade.A)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build();
+
+		ReportDTO dto = report.toReportDTO("contractor@example.com", "trainee@example.com");
+
+		assertTrue(dto.getIsFinalized());
+		assertEquals(finalizedAt, dto.getFinalizedAt());
+	}
+}

--- a/recon-report-service/src/test/resources/application.properties
+++ b/recon-report-service/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Test-scoped overrides for `mvn test` baseline.
+# Production properties under src/main/resources/application.properties depend on
+# env vars (APP_PORT, EUREKA_SERVICE_NAME, MYSQL_SERVICE_NAME) that are not set
+# during a plain `mvn test`, which breaks @SpringBootTest context loading.
+# These overrides keep the context self-contained: random port, no Eureka,
+# in-memory H2 instead of MySQL.
+
+spring.application.name=report-service
+
+# Random free port avoids unresolved ${APP_PORT} placeholder.
+server.port=0
+
+# Don't try to register with / fetch from a Eureka registry during tests.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+
+# In-memory H2 in MySQL-compat mode so JPA auto-config can stand up an
+# EntityManagerFactory without a running MySQL server.
+spring.datasource.url=jdbc:h2:mem:reportdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Use the production Hibernate dialect so Spring Data JPA's startup validation
+# of @Query JPQL recognizes MySQL HQL functions (e.g. DATE_FORMAT, YEAR, MONTH).
+# H2 only serves the underlying JDBC connection; no actual SQL is executed by
+# the contextLoads baseline test, so dialect/database mismatch is harmless here.
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+
+# Skip schema generation so Hibernate doesn't try to apply MySQL DDL to H2.
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- Adds finalize-report, trainee retort creation, and school report REST controllers/service endpoints in report-service.
- This PR is part of an ordered stack for the rating/finalization/retort/school visibility rollout.

## Review Order
- Review this after: PR #6

## Test plan
- [ ] Checkout this branch
- [ ] Run the service-level tests relevant to changed modules
- [ ] Verify behavior described in summary

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persistence and visibility rules (`isFinalized`, `Retort`) plus new read paths for trainee/school, which can affect data access behavior and requires coordinated DB/schema rollout. Changes are localized to report-service and covered by new unit/integration tests, lowering regression risk.
> 
> **Overview**
> Adds a *finalization* step to weekly reports, treating contractor-created reports as drafts until explicitly finalized, and surfaces finalization metadata (`isFinalized`, `finalizedAt`) in `ReportDTO`.
> 
> Introduces a new `Retort` entity (1:1 with `Report`) and API flow for trainees to create a single retort only after a report is finalized; returned report reads now include `retortContent`.
> 
> Expands the REST/service layer with new endpoints for contractors to finalize reports, trainees to read only finalized reports and create retorts, and a new school-facing controller that lists/reads only finalized reports using new `is_finalized = true` repository queries. Adds H2 test dependency and test properties to run `@SpringBootTest` without external MySQL/Eureka, plus new unit/integration tests covering finalization visibility and one-retort enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b48625196a4685b3ea459b495c10536dd65bc317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->