### PR TITLE
feat(reconV2): school JWT verification for report-service calls

### DIFF
--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
@@ -1,9 +1,11 @@
 package com.idea.recon.controller;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.exception.ReportException;
 import com.idea.recon.service.ReportService;
 
@@ -30,6 +33,17 @@ public class TraineeController {
 	ResponseEntity<List<String>> getMyContractorsWhoHaveReports(@RequestParam(value = "by") String byEmail, @RequestParam(value = "for") String forEmail, @RequestParam(value = "year") Integer year, @RequestParam(value = "month") String month, @RequestHeader (name="Authorization") String token) throws ReportException, Exception{
 		token = token.split(" ")[1];
 		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month, true), HttpStatus.OK);
+	}
+
+	@GetMapping("/get-report")
+	ResponseEntity<ReportDTO> getSchoolVisibleReport(
+			@RequestParam(value = "by") String byEmail,
+			@RequestParam(value = "for") String forEmail,
+			@RequestParam(value = "weekStart") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStartDate,
+			@RequestParam(value = "weekEnd") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekEndDate,
+			@RequestHeader(name = "Authorization") String token) throws ReportException, Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(reportService.getSchoolVisibleReport(byEmail, forEmail, token, weekStartDate, weekEndDate), HttpStatus.OK);
 	}
 	
 }

--- a/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
+++ b/recon-report-service/src/main/java/com/idea/recon/controller/TraineeController.java
@@ -29,7 +29,7 @@ public class TraineeController {
 	@GetMapping("/get-contractors")
 	ResponseEntity<List<String>> getMyContractorsWhoHaveReports(@RequestParam(value = "by") String byEmail, @RequestParam(value = "for") String forEmail, @RequestParam(value = "year") Integer year, @RequestParam(value = "month") String month, @RequestHeader (name="Authorization") String token) throws ReportException, Exception{
 		token = token.split(" ")[1];
-		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month), HttpStatus.OK);
+		return new ResponseEntity<>(reportService.getWeeksContainingReports(byEmail, forEmail, token, year, month, true), HttpStatus.OK);
 	}
 	
 }

--- a/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
+++ b/recon-report-service/src/main/java/com/idea/recon/dto/ReportDTO.java
@@ -1,6 +1,7 @@
 package com.idea.recon.dto;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
@@ -20,6 +21,8 @@ public class ReportDTO {
 	private LocalDate submissionDate; // ALWAYS GOTTEN FROM BACKEND
 	private LocalDate weekStartDate; // Start and End can be gotten from a single given date.
 	private LocalDate weekEndDate; // Might remove these in favor of just a single date
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	
 	// Not going to use entities because users should be contained
 	// in user-service

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -3,12 +3,15 @@ package com.idea.recon.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToOne;
 
 import com.idea.recon.dto.ReportDTO;
 import com.idea.recon.enums.Grade;
@@ -41,6 +44,9 @@ public class Report {
 	private Integer traineeLinkId;
 	private Boolean isFinalized;
 	private LocalDateTime finalizedAt;
+
+	@OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private Retort retort;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -1,6 +1,7 @@
 package com.idea.recon.entity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -38,6 +39,8 @@ public class Report {
 	
 	private Integer contractorLinkId;
 	private Integer traineeLinkId;
+	private Boolean isFinalized;
+	private LocalDateTime finalizedAt;
 	/*
 	 * title VARCHAR(50),
 	description VARCHAR(255),
@@ -65,6 +68,8 @@ public class Report {
 				.submissionDate(submissionDate)
 				.weekStartDate(weekStartDate)
 				.weekEndDate(weekEndDate)
+				.isFinalized(isFinalized)
+				.finalizedAt(finalizedAt)
 				.sentByEmail(sentBy)
 				.sentForEmail(sentFor)
 				.build();

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Report.java
@@ -19,7 +19,9 @@ import com.idea.recon.enums.Grade;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
@@ -45,6 +47,8 @@ public class Report {
 	private Boolean isFinalized;
 	private LocalDateTime finalizedAt;
 
+	@ToString.Exclude
+	@EqualsAndHashCode.Exclude
 	@OneToOne(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 	private Retort retort;
 	/*

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
@@ -13,7 +13,9 @@ import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
@@ -34,6 +36,8 @@ public class Retort {
 
 	private LocalDateTime createdAt;
 
+	@ToString.Exclude
+	@EqualsAndHashCode.Exclude
 	@OneToOne(optional = false)
 	@JoinColumn(name = "report_id", unique = true, nullable = false)
 	private Report report;

--- a/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
+++ b/recon-report-service/src/main/java/com/idea/recon/entity/Retort.java
@@ -1,0 +1,40 @@
+package com.idea.recon.entity;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "retort")
+public class Retort {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer retortId;
+
+	/** Trainee / junior contractor authoring the retort (minimal FK-style reference). */
+	private Integer traineeAuthorId;
+
+	private String content;
+
+	private LocalDateTime createdAt;
+
+	@OneToOne(optional = false)
+	@JoinColumn(name = "report_id", unique = true, nullable = false)
+	private Report report;
+}

--- a/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
@@ -47,6 +47,16 @@ public interface ReportRepository extends JpaRepository<Report, Integer> {
 			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year AND MONTH(week_start_date) = :month"
 	)
 	List<String> getWeeksWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year, Integer month);
+
+	/**
+	 * Same as {@link #getWeeksWithReportsOfContractorWithTrainee} but only weeks the school / trainee
+	 * may see ({@code is_finalized = true}).
+	 */
+	@Query("SELECT CONCAT(week_start_date, ' - ',  week_end_date) AS weekly_report FROM Report " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND YEAR(week_start_date) = :year AND MONTH(week_start_date) = :month "
+			+ "AND is_finalized = true"
+	)
+	List<String> getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(Integer contractorId, Integer traineeId, Integer year, Integer month);
 	
 }
 

--- a/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/ReportRepository.java
@@ -31,6 +31,15 @@ public interface ReportRepository extends JpaRepository<Report, Integer> {
 		       "FROM Report r " +
 		       "WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND week_start_date = :startOfWeek AND week_end_date = :endOfWeek")
 	Optional<Report>  getSpecificReport(Integer contractorId, Integer traineeId, LocalDate startOfWeek, LocalDate endOfWeek);
+
+	/** Same lookup as {@link #getSpecificReport} but only if the row is finalized (school / trainee reads). */
+	@Query("SELECT r " +
+			"FROM Report r " +
+			"WHERE contractor_link_id = :contractorId AND trainee_link_id = :traineeId AND week_start_date = :startOfWeek "
+			+ "AND week_end_date = :endOfWeek AND is_finalized = true")
+	Optional<Report> getSchoolVisibleSpecificReport(Integer contractorId, Integer traineeId, LocalDate startOfWeek,
+			LocalDate endOfWeek);
+
 	
 	
 	@Query("SELECT YEAR(week_start_date) AS year FROM Report " +

--- a/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
+++ b/recon-report-service/src/main/java/com/idea/recon/repository/RetortRepository.java
@@ -1,0 +1,12 @@
+package com.idea.recon.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.idea.recon.entity.Retort;
+
+public interface RetortRepository extends JpaRepository<Retort, Integer> {
+
+	Optional<Retort> findByReport_ReportId(Integer reportId);
+}

--- a/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
@@ -19,4 +19,10 @@ public interface ReportService {
 	public List<String> getMonthsContainingReports(String byEmail, String forEmail, String token, Integer year) throws ReportException, Exception;
 	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month) throws ReportException, Exception;
 
+	/**
+	 * @param finalizedOnly when true, only weeks with a finalized report are returned (school / trainee listings).
+	 *        When false, all saved reports for that relationship are included (contractor tooling).
+	 */
+	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year, String month, boolean finalizedOnly) throws ReportException, Exception;
+
 }

--- a/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/ReportService.java
@@ -2,17 +2,17 @@ package com.idea.recon.service;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
-import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
-import com.idea.recon.entity.Report;
 import com.idea.recon.exception.ReportException;
 
 public interface ReportService {
 	
 	public String createReport(ReportDTO reportDTO, String token) throws ReportException, Exception;
 	public ReportDTO getReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception;
+
+	/** Trainee / school read: same contract as {@link #getReport} but only returns a finalized report. */
+	public ReportDTO getSchoolVisibleReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception;
 	public ReportDTO updateReport(ReportDTO reportDTO, String token)throws ReportException, Exception;
 	
 	public List<String> getYearsContainingReports(String byEmail, String forEmail, String token) throws ReportException, Exception;

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -177,6 +177,12 @@ public class ReportServiceImpl implements ReportService {
 	@Override
 	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year,
 			String month) throws ReportException, Exception {
+		return getWeeksContainingReports(byEmail, forEmail, token, year, month, false);
+	}
+
+	@Override
+	public List<String> getWeeksContainingReports(String byEmail, String forEmail, String token, Integer year,
+			String month, boolean finalizedOnly) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
 		
@@ -212,7 +218,12 @@ public class ReportServiceImpl implements ReportService {
 		else
 			monthInt = Integer.valueOf(month);
 		
-		return reportRepository.getWeeksWithReportsOfContractorWithTrainee(relationship.getById(), relationship.getForId(), year, monthInt);
+		if (finalizedOnly) {
+			return reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(
+					relationship.getById(), relationship.getForId(), year, monthInt);
+		}
+		return reportRepository.getWeeksWithReportsOfContractorWithTrainee(
+				relationship.getById(), relationship.getForId(), year, monthInt);
 	}
 	
 	// PRIVATE METHDOS 

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -83,6 +83,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
@@ -117,6 +119,8 @@ public class ReportServiceImpl implements ReportService {
 				.submissionDate(report.getSubmissionDate())
 				.weekStartDate(report.getWeekStartDate())
 				.weekEndDate(report.getWeekEndDate())
+				.isFinalized(report.getIsFinalized())
+				.finalizedAt(report.getFinalizedAt())
 				//.sentForEmail(forEmail)
 				.title(report.getTitle())
 				.build();
@@ -143,6 +147,8 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(endOfWeek)
 				.contractorLinkId(response.getBody().getById())
 				.traineeLinkId(response.getBody().getForId())
+				.isFinalized(false)
+				.finalizedAt(null)
 				.build();
 		
 		report = reportRepository.save(report);

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -57,24 +57,46 @@ public class ReportServiceImpl implements ReportService {
 	public ReportDTO getReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
 		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
 		RelationshipVerificationDTO relationship = response.getBody();
-		
-		String regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
-		
-		if (!Pattern.matches(regex, startOfWeek.toString()) || !Pattern.matches(regex, endOfWeek.toString()))
-			throw new Exception("incorrect start or end date");
-		
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
 		Optional<Report> optionalReport = reportRepository.getSpecificReport(relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek);
 		logger.info(optionalReport.toString());
-		
+
 		if (optionalReport.isEmpty())
 			throw new Exception("No Report found for given date range: " + startOfWeek + " - " + endOfWeek);
-		
+
 		Report report = optionalReport.get();
-		logger.info(report.toString()); 
-		
+		logger.info(report.toString());
+		return toReadReportDto(report);
+	}
+
+	@Override
+	public ReportDTO getSchoolVisibleReport(String byEmail, String forEmail, String token, LocalDate startOfWeek, LocalDate endOfWeek) throws ReportException, Exception {
+		ResponseEntity<RelationshipVerificationDTO> response = verifyIdentity(token, byEmail, forEmail);
+		RelationshipVerificationDTO relationship = response.getBody();
+		validateWeekDateParams(startOfWeek, endOfWeek);
+
+		Optional<Report> optionalReport = reportRepository.getSchoolVisibleSpecificReport(
+				relationship.getById(), relationship.getForId(), startOfWeek, endOfWeek);
+		logger.info(optionalReport.toString());
+
+		if (optionalReport.isEmpty())
+			throw new Exception("No Report found for given date range: " + startOfWeek + " - " + endOfWeek);
+
+		Report report = optionalReport.get();
+		logger.info(report.toString());
+		return toReadReportDto(report);
+	}
+
+	private static void validateWeekDateParams(LocalDate startOfWeek, LocalDate endOfWeek) throws Exception {
+		String regex = "[0-9]{4}-[0-9]{2}-[0-9]{2}";
+		if (!Pattern.matches(regex, startOfWeek.toString()) || !Pattern.matches(regex, endOfWeek.toString()))
+			throw new Exception("incorrect start or end date");
+	}
+
+	private static ReportDTO toReadReportDto(Report report) {
 		String rebuttal = report.getRebuttal() == null ? "" : report.getRebuttal();
 		String title = report.getTitle() == null ? "" : report.getTitle();
-		
 		return ReportDTO.builder()
 				.reportId(report.getReportId())
 				.description(report.getDescription())
@@ -85,7 +107,6 @@ public class ReportServiceImpl implements ReportService {
 				.weekEndDate(report.getWeekEndDate())
 				.isFinalized(report.getIsFinalized())
 				.finalizedAt(report.getFinalizedAt())
-				//.sentForEmail(forEmail)
 				.title(title)
 				.build();
 	}

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -67,12 +67,22 @@ class ReportRetortVisibilityIntegrationTest {
 		assertThat(contractorWeeks).isNotEmpty();
 		assertThat(schoolWeeks).isEmpty();
 
+		assertThat(reportRepository.getSpecificReport(contractorId, traineeId, weekStart, weekEnd)).isPresent();
+		assertThat(reportRepository.getSchoolVisibleSpecificReport(contractorId, traineeId, weekStart, weekEnd)).isEmpty();
+
 		draft.setIsFinalized(true);
 		draft.setFinalizedAt(LocalDateTime.of(2026, 6, 7, 9, 0));
 		reportRepository.saveAndFlush(draft);
 
 		schoolWeeks = reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
 		assertThat(schoolWeeks).containsExactlyInAnyOrderElementsOf(contractorWeeks);
+
+		assertThat(reportRepository.getSchoolVisibleSpecificReport(contractorId, traineeId, weekStart, weekEnd))
+				.isPresent()
+				.hasValueSatisfying(r -> {
+					assertThat(r.getReportId()).isEqualTo(draft.getReportId());
+					assertThat(r.getIsFinalized()).isTrue();
+				});
 
 		Report finalized = reportRepository.findById(draft.getReportId()).orElseThrow();
 

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.idea.recon.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.idea.recon.entity.Report;
+import com.idea.recon.entity.Retort;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.repository.RetortRepository;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+		"spring.jpa.hibernate.ddl-auto=create-drop",
+})
+class ReportRetortVisibilityIntegrationTest {
+
+	@Autowired
+	private ReportRepository reportRepository;
+
+	@Autowired
+	private RetortRepository retortRepository;
+
+	@Test
+	void reportAllowsAtMostOneRetort_enforcedByDatabase() {
+		LocalDate weekStart = LocalDate.of(2026, 5, 4);
+		LocalDate weekEnd = LocalDate.of(2026, 5, 10);
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 15, 0);
+
+		Report finalizedReport = reportRepository.save(Report.builder()
+				.title("Weekly")
+				.description("Work done")
+				.grade(Grade.B)
+				.submissionDate(LocalDate.of(2026, 5, 7))
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.contractorLinkId(100)
+				.traineeLinkId(200)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build());
+
+		Retort first = Retort.builder()
+				.traineeAuthorId(555)
+				.content("Junior feedback")
+				.createdAt(LocalDateTime.of(2026, 5, 7, 16, 0))
+				.report(finalizedReport)
+				.build();
+
+		retortRepository.save(first);
+		retortRepository.flush();
+
+		assertThat(retortRepository.findByReport_ReportId(finalizedReport.getReportId())).isPresent();
+
+		Retort duplicateRetort = Retort.builder()
+				.traineeAuthorId(556)
+				.content("Attempted second retort")
+				.createdAt(LocalDateTime.of(2026, 5, 8, 10, 0))
+				.report(finalizedReport)
+				.build();
+
+		assertThatThrownBy(() -> {
+			retortRepository.save(duplicateRetort);
+			retortRepository.flush();
+		}).isInstanceOf(DataIntegrityViolationException.class);
+	}
+}

--- a/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/integration/ReportRetortVisibilityIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +32,61 @@ class ReportRetortVisibilityIntegrationTest {
 
 	@Autowired
 	private RetortRepository retortRepository;
+
+	@Test
+	void contractorDraft_schoolListingExcludesUntilFinalized_juniorCanAddRetort() {
+		Integer contractorId = 301;
+		Integer traineeId = 401;
+		LocalDate weekStart = LocalDate.of(2026, 6, 1);
+		LocalDate weekEnd = LocalDate.of(2026, 6, 7);
+
+		Report draft = reportRepository.save(Report.builder()
+				.title("Draft weekly")
+				.description("Saved by contractor")
+				.grade(Grade.B)
+				.submissionDate(LocalDate.of(2026, 6, 7))
+				.weekStartDate(weekStart)
+				.weekEndDate(weekEnd)
+				.contractorLinkId(contractorId)
+				.traineeLinkId(traineeId)
+				.isFinalized(false)
+				.finalizedAt(null)
+				.build());
+
+		assertThat(draft.getReportId()).isNotNull();
+		assertThat(draft.getIsFinalized()).isFalse();
+
+		int year = 2026;
+		int month = 6;
+
+		List<String> contractorWeeks =
+				reportRepository.getWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+		List<String> schoolWeeks =
+				reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+
+		assertThat(contractorWeeks).isNotEmpty();
+		assertThat(schoolWeeks).isEmpty();
+
+		draft.setIsFinalized(true);
+		draft.setFinalizedAt(LocalDateTime.of(2026, 6, 7, 9, 0));
+		reportRepository.saveAndFlush(draft);
+
+		schoolWeeks = reportRepository.getSchoolVisibleWeeksWithReportsOfContractorWithTrainee(contractorId, traineeId, year, month);
+		assertThat(schoolWeeks).containsExactlyInAnyOrderElementsOf(contractorWeeks);
+
+		Report finalized = reportRepository.findById(draft.getReportId()).orElseThrow();
+
+		retortRepository.save(Retort.builder()
+				.traineeAuthorId(902)
+				.content("Junior retort after finalize")
+				.createdAt(LocalDateTime.of(2026, 6, 7, 10, 30))
+				.report(finalized)
+				.build());
+		retortRepository.flush();
+
+		assertThat(retortRepository.findByReport_ReportId(finalized.getReportId()))
+				.hasValueSatisfying(r -> assertThat(r.getContent()).isEqualTo("Junior retort after finalize"));
+	}
 
 	@Test
 	void reportAllowsAtMostOneRetort_enforcedByDatabase() {

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.idea.recon.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.idea.recon.dto.RelationshipVerificationDTO;
+import com.idea.recon.dto.ReportDTO;
+import com.idea.recon.entity.Report;
+import com.idea.recon.enums.Grade;
+import com.idea.recon.repository.ReportRepository;
+import com.idea.recon.utility.MicroserviceUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceImplTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	@Mock
+	private MicroserviceUtil microserviceUtil;
+
+	@Mock
+	private ReportRepository reportRepository;
+
+	@InjectMocks
+	private ReportServiceImpl reportService;
+
+	@Test
+	void createReportDefaultsToDraftStateForContractorSubmission() throws Exception {
+		RelationshipVerificationDTO relationship = RelationshipVerificationDTO.builder()
+				.byId(10)
+				.forId(20)
+				.byName("Contractor Name")
+				.forName("Trainee Name")
+				.byEmail("contractor@example.com")
+				.forEmail("trainee@example.com")
+				.build();
+
+		ReportDTO reportDTO = ReportDTO.builder()
+				.title("Weekly Report")
+				.description("Progress update")
+				.grade("A")
+				.sentByEmail("contractor@example.com")
+				.sentForEmail("trainee@example.com")
+				.weekStartDate(LocalDate.of(2026, 5, 4))
+				.weekEndDate(LocalDate.of(2026, 5, 10))
+				.build();
+
+		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
+		when(reportRepository.contractorReportExist(eq(10), eq(20), eq(LocalDate.of(2026, 5, 4)),
+				eq(LocalDate.of(2026, 5, 10)))).thenReturn(false);
+		when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+			Report report = invocation.getArgument(0);
+			report.setReportId(99);
+			return report;
+		});
+		when(restTemplate.exchange(contains("/email/report-created"), eq(HttpMethod.POST), any(HttpEntity.class),
+				eq(String.class))).thenReturn(ResponseEntity.ok("ok"));
+
+		String result = reportService.createReport(reportDTO, "token");
+
+		ArgumentCaptor<Report> reportCaptor = ArgumentCaptor.forClass(Report.class);
+		verify(reportRepository).save(reportCaptor.capture());
+		Report savedReport = reportCaptor.getValue();
+
+		assertEquals("Report Created.", result);
+		assertFalse(savedReport.getIsFinalized());
+		assertNull(savedReport.getFinalizedAt());
+	}
+
+	@Test
+	void toReportDtoIncludesFinalizationMetadata() {
+		LocalDateTime finalizedAt = LocalDateTime.of(2026, 5, 7, 12, 30);
+		Report report = Report.builder()
+				.reportId(7)
+				.title("Title")
+				.description("Body")
+				.grade(Grade.A)
+				.isFinalized(true)
+				.finalizedAt(finalizedAt)
+				.build();
+
+		ReportDTO dto = report.toReportDTO("contractor@example.com", "trainee@example.com");
+
+		assertTrue(dto.getIsFinalized());
+		assertEquals(finalizedAt, dto.getFinalizedAt());
+	}
+}

--- a/recon-report-service/src/test/resources/application.properties
+++ b/recon-report-service/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# Test-scoped overrides for `mvn test` baseline.
+# Production properties under src/main/resources/application.properties depend on
+# env vars (APP_PORT, EUREKA_SERVICE_NAME, MYSQL_SERVICE_NAME) that are not set
+# during a plain `mvn test`, which breaks @SpringBootTest context loading.
+# These overrides keep the context self-contained: random port, no Eureka,
+# in-memory H2 instead of MySQL.
+
+spring.application.name=report-service
+
+# Random free port avoids unresolved ${APP_PORT} placeholder.
+server.port=0
+
+# Don't try to register with / fetch from a Eureka registry during tests.
+eureka.client.enabled=false
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+spring.cloud.discovery.enabled=false
+
+# In-memory H2 in MySQL-compat mode so JPA auto-config can stand up an
+# EntityManagerFactory without a running MySQL server.
+spring.datasource.url=jdbc:h2:mem:reportdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Use the production Hibernate dialect so Spring Data JPA's startup validation
+# of @Query JPQL recognizes MySQL HQL functions (e.g. DATE_FORMAT, YEAR, MONTH).
+# H2 only serves the underlying JDBC connection; no actual SQL is executed by
+# the contextLoads baseline test, so dialect/database mismatch is harmless here.
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+
+# Skip schema generation so Hibernate doesn't try to apply MySQL DDL to H2.
+spring.jpa.hibernate.ddl-auto=none

--- a/reconV2/src/main/java/com/idea/recon/config/AWSStorageConfig.java
+++ b/reconV2/src/main/java/com/idea/recon/config/AWSStorageConfig.java
@@ -1,6 +1,6 @@
 package com.idea.recon.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,46 +9,28 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.Region;
-
-//import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-//import software.amazon.awssdk.regions.Region;
-//import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class AWSStorageConfig {
-	
-	String accessKey = System.getenv("AWS_ACCESS_KEY_ID");
-	String accessSecret = System.getenv("AWS_SECRET_ACCESS_KEY");
-	String region = "us-east-2";
-	
-	/*@Value("${cloud.aws.credentials.access-key}")
-	private String accessKey;
-	
-	@Value("${cloud.aws.credentials.secret-key}")
-	private String accessSecret;
-	
-	@Value("${cloud.aws.region.static}")
-	private String region;*/
+
+	private final org.slf4j.Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	@Bean
 	public AmazonS3 generateS3Client() {
+		String accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+		String accessSecret = System.getenv("AWS_SECRET_ACCESS_KEY");
+		String region = System.getenv().getOrDefault("AWS_REGION", "us-east-2");
+		if (accessKey == null || accessSecret == null) {
+			throw new IllegalStateException(
+					"Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (or use instance profile / default provider in a future refactor).");
+		}
+		logger.info("S3 client using region: {}", region);
 		AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
-		
+
 		return AmazonS3ClientBuilder.standard()
 				.withCredentials(new AWSStaticCredentialsProvider(credentials))
 				.withRegion(region)
 				.build();
 	}
-	
-	/*
-	@Bean
-	public S3Client generateS3Client() {
-	S3Client s3Client = S3Client.builder()
-	        .region(Region.US_EAST_1) // Replace with your desired region
-	        .credentialsProvider(DefaultCredentialsProvider.create())
-	        .build();
-	return s3Client;
-	}*/
-	
+
 }

--- a/reconV2/src/main/java/com/idea/recon/config/JwtRequestFilter.java
+++ b/reconV2/src/main/java/com/idea/recon/config/JwtRequestFilter.java
@@ -96,7 +96,8 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 			logger.info(request.getRequestURI());
 			
 			UserDetails userDetails;
-			if(request.getRequestURI().startsWith("/verify/contractor-to-trainee")) {
+			if (request.getRequestURI().startsWith("/verify/contractor-to-trainee")
+					|| request.getRequestURI().startsWith("/verify/trainee/contractor-to-trainee")) {
 				String role = jwtTokenUtil.getRoleFromToken(jwtToken);
 				if (role.equalsIgnoreCase("trainee")) {
 					try {
@@ -116,6 +117,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 		        	}
 				} else { 
 					handlerExceptionResolver.resolveException(request, response, null, new Exception("NOOOO"));
+					return;
+				}
+			} else if (request.getRequestURI().startsWith("/verify/school/contractor-to-trainee")) {
+				try {
+					logger.info("JwtRequestFilter: use SchoolDetailsService (school verify)");
+					userDetails = jwtSchoolDetailsService.loadUserByUsername(username);
+				} catch (Exception ex) {
+					handlerExceptionResolver.resolveException(request, response, null, ex);
 					return;
 				}
 			}

--- a/reconV2/src/main/java/com/idea/recon/controllers/ContractorController.java
+++ b/reconV2/src/main/java/com/idea/recon/controllers/ContractorController.java
@@ -67,7 +67,7 @@ public class ContractorController {
 	@PreAuthorize("hasAuthority('contractor')")
 	ResponseEntity<String> updateMyDetails(@RequestBody ContractorDTO updateInfo, @PathVariable Integer id, @RequestHeader (name="Authorization") String token) throws Exception {
 		token = token.split(" ")[1];
-		updateInfo.setId(id);
+		updateInfo.setId(id); // either add id to object in front or add id param to service method
 		return new ResponseEntity<>(contractorService.updateMyDetails(updateInfo, token), HttpStatus.OK);
 	}
 	

--- a/reconV2/src/main/java/com/idea/recon/controllers/HealthCheckController.java
+++ b/reconV2/src/main/java/com/idea/recon/controllers/HealthCheckController.java
@@ -1,0 +1,5 @@
+package com.idea.recon.controllers;
+
+public class HealthCheckController {
+
+}

--- a/reconV2/src/main/java/com/idea/recon/controllers/SchoolController.java
+++ b/reconV2/src/main/java/com/idea/recon/controllers/SchoolController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.idea.recon.config.JwtTokenUtil;
+import com.idea.recon.dtos.ContractorDTO;
 import com.idea.recon.dtos.SchoolDTO;
 import com.idea.recon.dtos.TraineeDTO;
 import com.idea.recon.services.SchoolService;
@@ -75,6 +76,11 @@ public class SchoolController {
 		return new ResponseEntity<>(schoolService.RegisterContractor(id, contractorEmail, token), HttpStatus.CREATED);
 	}
 	
-	
+	/*@GetMapping(value = "/{id}/contractors")
+	@PreAuthorize("hasAuthority('school')")
+	ResponseEntity<Set<ContractorDTO>> getMyStudents(@PathVariable Integer id, @RequestHeader (name="Authorization") String token) throws Exception {
+		token = token.split(" ")[1];
+		return null;//return new ResponseEntity<>(schoolService.getStudents(id, token), HttpStatus.OK);
+	}*/
 
 }

--- a/reconV2/src/main/java/com/idea/recon/controllers/VerificationController.java
+++ b/reconV2/src/main/java/com/idea/recon/controllers/VerificationController.java
@@ -31,4 +31,29 @@ public class VerificationController {
 		token = token.split(" ")[1];
 		return new ResponseEntity<>(verificationService.route(byEmail, forEmail, token), HttpStatus.OK);
 	}
+
+	/**
+	 * Same payload as {@link #verifyContractorTraineeRelationship} but only callable with a trainee JWT.
+	 * Used by downstream services (e.g. report-service) that must enforce junior-only actions.
+	 */
+	@GetMapping(value = "/trainee/contractor-to-trainee")
+	@PreAuthorize("hasAuthority('trainee')")
+	ResponseEntity<RelationshipVerificationDTO> verifyContractorTraineeRelationshipAsTraineeOnly(
+			@RequestParam(value = "by") String byEmail,
+			@RequestParam(value = "for") String forEmail,
+			@RequestHeader(name = "Authorization") String token) throws Exception {
+		logger.info("trainee-only verify: by={}, for={}", byEmail, forEmail);
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(verificationService.route(byEmail, forEmail, token), HttpStatus.OK);
+	}
+
+	@GetMapping(value = "/school/contractor-to-trainee")
+	@PreAuthorize("hasAuthority('school')")
+	ResponseEntity<RelationshipVerificationDTO> verifySchoolTraineeContractor(
+			@RequestParam(value = "by") String byEmail,
+			@RequestParam(value = "for") String forEmail,
+			@RequestHeader(name = "Authorization") String token) throws Exception {
+		token = token.split(" ")[1];
+		return new ResponseEntity<>(verificationService.routeSchool(byEmail, forEmail, token), HttpStatus.OK);
+	}
 }

--- a/reconV2/src/main/java/com/idea/recon/services/VerificationService.java
+++ b/reconV2/src/main/java/com/idea/recon/services/VerificationService.java
@@ -7,6 +7,10 @@ import com.idea.recon.exceptions.TraineeException;
 public interface VerificationService {
 
 	public RelationshipVerificationDTO route(String contractorEmail, String traineeEmail, String token) throws ContractorException, TraineeException;
+
+	/** School may read finalized contractor↔trainee reports only when the trainee is on the school's roster and supervised by the contractor. */
+	RelationshipVerificationDTO routeSchool(String contractorEmail, String traineeEmail, String token)
+			throws ContractorException, TraineeException;
 	//RelationshipVerificationDTO confirmContractorToTraineeConnection(String contractorEmail, String traineeEmail, String token) throws ContractorException, TraineeException;
 	//RelationshipVerificationDTO confirmTraineeToContractorConnection(String contractorEmail, String traineeEmail, String token) throws ContractorException, TraineeException;
 	

--- a/reconV2/src/main/java/com/idea/recon/services/impl/VerificationServiceImpl.java
+++ b/reconV2/src/main/java/com/idea/recon/services/impl/VerificationServiceImpl.java
@@ -7,14 +7,17 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.idea.recon.config.JwtTokenUtil;
 import com.idea.recon.dtos.RelationshipVerificationDTO;
 import com.idea.recon.entities.Contractor;
+import com.idea.recon.entities.School;
 import com.idea.recon.entities.Trainee;
 import com.idea.recon.exceptions.ContractorException;
 import com.idea.recon.exceptions.TraineeException;
 import com.idea.recon.repositories.ContractorRepository;
+import com.idea.recon.repositories.SchoolRepository;
 import com.idea.recon.repositories.TraineeRepository;
 import com.idea.recon.services.ContractorService;
 import com.idea.recon.services.TraineeService;
@@ -43,7 +46,14 @@ public class VerificationServiceImpl implements VerificationService {
 	@Autowired
 	@Qualifier("jwtContractorDetailsService")
 	private UserDetailsService jwtContractorDetailsService;
-	
+
+	@Autowired
+	@Qualifier("jwtSchoolDetailsService")
+	private UserDetailsService jwtSchoolDetailsService;
+
+	@Autowired
+	SchoolRepository schoolRepository;
+
 	public RelationshipVerificationDTO route(String contractorEmail, String traineeEmail, String token) throws ContractorException, TraineeException {
 		String role = jwtTokenUtil.getRoleFromToken(token);
 		if (role.equalsIgnoreCase("trainee"))
@@ -115,6 +125,36 @@ public class VerificationServiceImpl implements VerificationService {
 				.build();
 		
 		return relationship;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public RelationshipVerificationDTO routeSchool(String contractorEmail, String traineeEmail, String token)
+			throws ContractorException, TraineeException {
+		UserDetails user = jwtSchoolDetailsService.loadUserByUsername(jwtTokenUtil.getUsernameFromToken(token));
+		boolean isAdmin = user.getAuthorities().contains(new SimpleGrantedAuthority("admin"));
+		School school = schoolRepository.getByEmail(user.getUsername())
+				.orElseThrow(() -> new ContractorException("School.NOT_FOUND"));
+		Trainee trainee = traineeService.getTraineeByEmail(traineeEmail);
+
+		if (!isAdmin) {
+			boolean schoolHasTrainee = school.getStudents() != null && school.getStudents().stream()
+					.anyMatch(st -> st.getTrainee() != null
+							&& st.getTrainee().getTraineeId().equals(trainee.getTraineeId()));
+			if (!schoolHasTrainee)
+				throw new ContractorException("Contractor.TRAINEE_NOT_LINKED");
+		}
+
+		Contractor contractor = contractorService.getContractorByEmail(contractorEmail);
+		if (!contractor.getTrainees().contains(trainee))
+			throw new ContractorException("Contractor.TRAINEE_NOT_LINKED");
+
+		return RelationshipVerificationDTO.builder()
+				.byId(contractor.getId())
+				.byName(contractor.getFirstName() + " " + contractor.getLastName())
+				.forId(trainee.getTraineeId())
+				.forName(trainee.getFirstName() + " " + trainee.getLastName())
+				.build();
 	}
 
 }


### PR DESCRIPTION
## Summary
- Adds school JWT verification route/filter/service plumbing in reconV2 for secure report-service school checks.
- This PR is part of an ordered stack for the rating/finalization/retort/school visibility rollout.

## Review Order
- Review this after: PR #6 (and coordinate with PR #7 integration)

## Test plan
- [ ] Checkout this branch
- [ ] Run the service-level tests relevant to changed modules
- [ ] Verify behavior described in summary

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization/verification routing in `reconV2` and adds new persistence fields/entities in `recon-report-service`, which can affect access control and database behavior if misconfigured.
> 
> **Overview**
> **Adds finalized-only visibility paths for trainee/school report reads.** `recon-report-service` now tracks report finalization (`isFinalized`, `finalizedAt`), exposes a new trainee endpoint to fetch a finalized report, and updates week listings/queries to optionally filter out non-finalized drafts.
> 
> **Introduces retorts as a new one-to-one entity on reports.** Adds `Retort` + `RetortRepository` with DB-level uniqueness (one retort per report) and integration tests covering finalized visibility and retort constraints.
> 
> **Extends reconV2 verification/JWT plumbing for school and trainee-only verification.** Adds `/verify/trainee/contractor-to-trainee` and `/verify/school/contractor-to-trainee`, updates `JwtRequestFilter` to authenticate these routes correctly, and implements `VerificationService.routeSchool` to enforce school roster + contractor supervision checks.
> 
> **Improves testability and config safety.** Adds H2 test dependency and test `application.properties` to run Spring tests without external MySQL/Eureka, and hardens S3 client config to require AWS creds and log region.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3cbfc65734041051666ec709f14979ba1067c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->