### PR TITLE
Add Docker Compose fullstack overlay for local React dev

### DIFF
--- a/.env
+++ b/.env
@@ -21,3 +21,7 @@ RECON_MYSQL_APP_PORT=0
 # Common values
 EUREKA_SERVICE_NAME=eureka
 MYSQL_SERVICE_NAME=mysql
+
+# Fullstack overlay (docker-compose.fullstack.yml)
+RECON_CLIENT_HOST_PORT=3000
+RECON_CLIENT_CONTEXT=../MERN/Recon/recon-client

--- a/README.md
+++ b/README.md
@@ -1,6 +1,34 @@
 # Recon
 
-Java backend implmentation of Recon Project. 
+Java backend implementation of Recon Project.
 
-Frontend is in React
+Frontend (React) lives in the MERN repo: `../MERN/Recon/recon-client` (path configurable via `RECON_CLIENT_CONTEXT` in `.env`).
 
+## Docker — backend only
+
+```bash
+docker compose up --build
+```
+
+| Service | URL |
+|---------|-----|
+| Core (auth, profile) | http://localhost:4000 |
+| Reports | http://localhost:4001 |
+| Email | http://localhost:4003 |
+| Eureka | http://localhost:8761 |
+
+## Docker — full stack (backend + React dev server)
+
+Requires the client repo checked out at `RECON_CLIENT_CONTEXT` (default: `../MERN/Recon/recon-client`).
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build
+```
+
+Open http://localhost:3000 — the browser calls APIs on `localhost:4000` / `localhost:4001` (host-mapped backend ports).
+
+Stop everything:
+
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml down
+```

--- a/docker-compose.fullstack.yml
+++ b/docker-compose.fullstack.yml
@@ -1,0 +1,19 @@
+# Local dev overlay — adds the React client to the backend stack.
+# Usage: docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build
+services:
+  recon-client:
+    build:
+      context: ${RECON_CLIENT_CONTEXT}
+      dockerfile: Dockerfile.dev
+    env_file:
+      - env/recon-client.env
+    ports:
+      - ${RECON_CLIENT_HOST_PORT:-3000}:3000
+    volumes:
+      - ${RECON_CLIENT_CONTEXT}/src:/app/src
+      - ${RECON_CLIENT_CONTEXT}/public:/app/public
+    depends_on:
+      - recon-core
+      - recon-reports
+    stdin_open: true
+    tty: true

--- a/env/recon-client.env
+++ b/env/recon-client.env
@@ -1,0 +1,7 @@
+PORT=3000
+BROWSER=none
+REACT_APP_API_BASE_URL=http://localhost:4000
+REACT_APP_REPORTS_BASE_URL=http://localhost:4001
+CHOKIDAR_USEPOLLING=true
+WDS_SOCKET_HOST=localhost
+NODE_OPTIONS=--openssl-legacy-provider


### PR DESCRIPTION
## Summary
- Adds `docker-compose.fullstack.yml` as an optional merge overlay on top of the existing backend compose file.
- Adds `env/recon-client.env` with CRA dev settings pointing at host-mapped API ports (`localhost:4000` / `:4001`).
- Documents backend-only vs fullstack commands in README and adds `RECON_CLIENT_*` variables to `.env`.

Pair with MERN PR adding `Dockerfile.dev` in recon-client.

## Usage
```bash
docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build
```
Open http://localhost:3000

## Test plan
- [x] Backend-only compose still works unchanged
- [x] Fullstack compose starts 6 services (mysql, eureka, core, reports, email, client)
- [x] http://localhost:3000 returns 200
- [x] Contractor login against http://localhost:4000 succeeds


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional Docker Compose overlay and env/docs for local React dev without changing backend runtime behavior.
> 
> **Overview**
> Adds an optional **Docker Compose fullstack overlay** (`docker-compose.fullstack.yml`) that brings up a `recon-client` React dev server alongside the existing backend services, with bind mounts for live-reload.
> 
> Introduces `env/recon-client.env` and new `.env` variables (`RECON_CLIENT_CONTEXT`, `RECON_CLIENT_HOST_PORT`) to configure the client build context/port, and updates `README.md` with backend-only vs fullstack run commands and URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14463d9618b0887f87a36e6ec3d011ac335b25f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->