### PR TITLE
Add Docker Compose healthchecks via Actuator

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,12 @@ services:
       - ./env/mysql.env
     volumes:
       - /Users/repoleved/Desktop/docker/recon-mysql:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
   eureka:
     build: 
       context: ./recon-discovery-service
@@ -14,6 +20,12 @@ services:
       - env/recon-eureka.env
     ports:
       - $RECON_EUREKA_HOST_PORT:$RECON_EUREKA_APP_PORT
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8761/actuator/health | grep -q UP"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 90s
   recon-core:
     build:
       context: ./reconV2
@@ -23,8 +35,16 @@ services:
     ports:
       - $RECON_CORE_HOST_PORT:$RECON_CORE_APP_PORT
     depends_on:
-      - eureka
-      - mysql
+      eureka:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4000/actuator/health | grep -q UP"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 120s
   recon-reports:
     build:
       context: ./recon-report-service
@@ -34,8 +54,16 @@ services:
     ports:
       - $RECON_REPORT_HOST_PORT:$RECON_REPORT_APP_PORT
     depends_on:
-      - eureka
-      - mysql
+      eureka:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4001/actuator/health | grep -q UP"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 120s
   recon-email:
     build:
       context: ./recon-email-service
@@ -45,6 +73,13 @@ services:
     ports:
       - $RECON_EMAIL_HOST_PORT:$RECON_EMAIL_APP_PORT
     depends_on:
-      - eureka
-      - mysql
-
+      eureka:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4003/actuator/health | grep -q UP"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 120s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     ports:
       - $RECON_EUREKA_HOST_PORT:$RECON_EUREKA_APP_PORT
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8761/actuator/health | grep -q UP"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${APP_PORT}/actuator/health > /dev/null"]
       interval: 15s
       timeout: 5s
       retries: 12
@@ -40,7 +40,7 @@ services:
       mysql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:4000/actuator/health | grep -q UP"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${APP_PORT}/actuator/health > /dev/null"]
       interval: 15s
       timeout: 5s
       retries: 12
@@ -59,7 +59,7 @@ services:
       mysql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:4001/actuator/health | grep -q UP"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${APP_PORT}/actuator/health > /dev/null"]
       interval: 15s
       timeout: 5s
       retries: 12
@@ -78,7 +78,7 @@ services:
       mysql:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:4003/actuator/health | grep -q UP"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:$${APP_PORT}/actuator/health > /dev/null"]
       interval: 15s
       timeout: 5s
       retries: 12

--- a/recon-discovery-service/Dockerfile
+++ b/recon-discovery-service/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazoncorretto:17
 
+RUN yum install -y curl && yum clean all
 
 COPY .mvn/ .mvn
 COPY mvnw pom.xml ./

--- a/recon-email-service/Dockerfile
+++ b/recon-email-service/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazoncorretto:17
 
+RUN yum install -y curl && yum clean all
 
 COPY .mvn/ .mvn
 COPY mvnw pom.xml ./

--- a/recon-report-service/Dockerfile
+++ b/recon-report-service/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazoncorretto:17
 
+RUN yum install -y curl && yum clean all
 
 COPY .mvn/ .mvn
 COPY mvnw pom.xml ./

--- a/reconV2/Dockerfile
+++ b/reconV2/Dockerfile
@@ -1,5 +1,6 @@
 FROM amazoncorretto:17
 
+RUN yum install -y curl && yum clean all
 
 COPY .mvn/ .mvn
 COPY mvnw pom.xml ./


### PR DESCRIPTION
## Summary
- Adds `healthcheck` blocks for MySQL (mysqladmin ping) and all Spring services (`/actuator/health`).
- Switches `depends_on` to `condition: service_healthy` for core, reports, and email.

## Why
Reduces startup race conditions where API/login calls fail before services are ready.

## Test plan
- [ ] `docker compose up --build` — all services reach healthy
- [ ] `curl http://localhost:4000/actuator/health` → UP
- [ ] Contractor login succeeds without waiting manually

**Merge after:** #14 (fullstack overlay). May conflict with #17 on `docker-compose.yaml` — merge this before #17.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Docker Compose healthcheck commands and Dockerfile package installs; main risk is misconfigured `APP_PORT` env causing containers to stay unhealthy.
> 
> **Overview**
> Standardizes Spring service Docker Compose healthchecks to hit `/actuator/health` on `localhost:$${APP_PORT}` (instead of hardcoded ports / `grep -q UP`).
> 
> Updates all Spring service Dockerfiles to install `curl` so the healthcheck command is available inside the containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ededf132fe6f49a56101e5ad8179586e4575d05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->