### PR TITLE
Use named Docker volume for MySQL data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     env_file:
       - ./env/mysql.env
     volumes:
-      - /Users/repoleved/Desktop/docker/recon-mysql:/var/lib/mysql
+      - recon-mysql-data:/var/lib/mysql
   eureka:
     build: 
       context: ./recon-discovery-service
@@ -48,3 +48,5 @@ services:
       - eureka
       - mysql
 
+volumes:
+  recon-mysql-data:


### PR DESCRIPTION
## Summary
- Replaces machine-specific bind mount (`/Users/.../Desktop/docker/recon-mysql`) with `recon-mysql-data` named volume.

## Why
Makes local Docker setup portable across developer machines.

## Test plan
- [ ] `docker compose up --build` — MySQL starts and data persists across restarts
- [ ] Existing seeded users still login after volume migration (fresh volume = re-seed needed)

**Merge after:** #15 (healthchecks) to avoid compose conflicts.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Compose-only change that affects local MySQL data persistence; the main risk is developers unintentionally starting with a fresh volume and losing prior local data.
> 
> **Overview**
> Switches the MySQL data directory from a machine-specific host bind mount to a portable named volume (`recon-mysql-data`) in `docker-compose.yaml`.
> 
> Adds a top-level `volumes:` definition for the new named volume so MySQL state persists across container restarts without relying on a developer-specific filesystem path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa69667d61a55f40343a805523097636d583b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->