### PR TITLE
Document local Docker dev and smoke tests

### DIFF
--- a/docs/local-dev-setup.md
+++ b/docs/local-dev-setup.md
@@ -1,0 +1,84 @@
+# Recon local development
+
+## Service map
+
+| Service | Container | Host URL | Purpose |
+|---------|-----------|----------|---------|
+| MySQL | `mysql` | internal `:3306` | Seeded `recon` database |
+| Eureka | `eureka` | http://localhost:8761 | Service discovery |
+| Core (user-service) | `recon-core` | http://localhost:4000 | Auth, profile, connections |
+| Reports | `recon-reports` | http://localhost:4001 | Weekly reports API |
+| Email | `recon-email` | http://localhost:4003 | SES email service |
+| React client (optional) | `recon-client` | http://localhost:3000 | CRA dev server via fullstack overlay |
+
+## Quick start
+
+**Backend only:**
+```bash
+docker compose up --build
+```
+
+**Full stack (requires MERN `recon-client` at `RECON_CLIENT_CONTEXT`):**
+```bash
+docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build
+```
+
+**Stop:**
+```bash
+docker compose down
+# or with fullstack:
+docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml down
+```
+
+## Seeded test users
+
+Password for all: `password`
+
+| Role | Email |
+|------|-------|
+| Contractor | `contractor.1@yahoo.com` |
+| Trainee | `trainee.1@yahoo.com` |
+| School | `school.1@yahoo.com` |
+
+## Smoke tests
+
+**Public endpoint:**
+```bash
+curl http://localhost:4000/user/test
+```
+
+**Login (contractor):**
+```bash
+curl -s -H "Content-Type: application/json" \
+  -d '{"username":"contractor.1@yahoo.com","password":"password"}' \
+  http://localhost:4000/user/authenticate/contractor
+```
+
+**Actuator health:**
+```bash
+curl http://localhost:4000/actuator/health
+curl http://localhost:4001/actuator/health
+curl http://localhost:8761/actuator/health
+```
+
+**Frontend (Playwright, from MERN repo):**
+```bash
+cd Recon/recon-client
+PLAYWRIGHT_SKIP_WEB_SERVER=1 PLAYWRIGHT_BASE_URL=http://localhost:3000 \
+  npx playwright test e2e/docker-backend-smoke.spec.js
+```
+
+## Environment files
+
+| File | Purpose |
+|------|---------|
+| `.env` | Host port mappings, `RECON_CLIENT_CONTEXT` |
+| `env/recon-core.env` | Core service ports + AWS placeholders for local Docker |
+| `env/recon-report.env` | Report service |
+| `env/recon-client.env` | CRA env for fullstack overlay |
+
+## Known local-dev gaps
+
+- `/bucket/picture` returns 400 without real S3 — UI falls back to default avatar
+- Report month/week dropdowns stay empty until a year is selected (cascade UX)
+- Report service returns 500 (not 401) when `Authorization` header is missing


### PR DESCRIPTION
## Summary
- Adds `docs/local-dev-setup.md` with service map, seeded users, curl smoke commands, and known local-dev gaps.

## Test plan
- [ ] Doc paths and ports match current `.env` defaults

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds local dev instructions and does not affect runtime behavior.
> 
> **Overview**
> Adds `docs/local-dev-setup.md` documenting local Docker development: service/port map, backend vs fullstack `docker compose` commands, seeded test users, and basic curl/actuator smoke tests.
> 
> Also lists relevant `.env`/service env files and a short set of known local-dev gaps to set expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f8a419394cff1142ab6d8f337d2413b7228f79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->