### PR TITLE
Fix recon-core config server hostname for Docker

### DIFF
--- a/reconV2/src/main/resources/application.properties
+++ b/reconV2/src/main/resources/application.properties
@@ -4,7 +4,7 @@ eureka.client.service-url.defaultZone=http://${EUREKA_SERVICE_NAME}:8761/eureka
 
 #Clint info
 server.port=${APP_PORT}
-spring.config.import=optional:configserver:http://localhost:8761
+spring.config.import=optional:configserver:http://${EUREKA_SERVICE_NAME}:8761
 spring.application.name=user-service
 
 # JWT INFORMATION 


### PR DESCRIPTION
## Summary
- Point `spring.config.import` config server URL at `${EUREKA_SERVICE_NAME}:8761` instead of `localhost:8761`
- Removes startup warnings when running under Docker Compose

## Test plan
- [ ] `docker compose up` — recon-core logs no longer show connection refused to `localhost:8761`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; behavior mainly depends on correct `${EUREKA_SERVICE_NAME}` being set in each environment.
> 
> **Overview**
> Updates `spring.config.import` in `application.properties` to resolve the Spring Config Server via `${EUREKA_SERVICE_NAME}:8761` instead of `localhost`, improving service discovery/bootstrapping when running in Docker/Compose and avoiding connection attempts to the local machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92d01f1e0e1110fa6a834664d7bff461771c130a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->