### PR TITLE
Wait for healthy backends in fullstack compose overlay

### DIFF
--- a/docker-compose.fullstack.yml
+++ b/docker-compose.fullstack.yml
@@ -13,7 +13,9 @@ services:
       - ${RECON_CLIENT_CONTEXT}/src:/app/src
       - ${RECON_CLIENT_CONTEXT}/public:/app/public
     depends_on:
-      - recon-core
-      - recon-reports
+      recon-core:
+        condition: service_healthy
+      recon-reports:
+        condition: service_healthy
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary
- Change `recon-client` `depends_on` to use `service_healthy` for `recon-core` and `recon-reports`
- Prevents the frontend from starting before backend APIs are ready

## Test plan
- [ ] `docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build`
- [ ] `recon-client` starts only after core/reports healthchecks pass


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Docker Compose startup ordering for local dev by gating `recon-client` on existing backend healthchecks.
> 
> **Overview**
> Updates `docker-compose.fullstack.yml` so `recon-client` waits for `recon-core` and `recon-reports` to become *healthy* (via `depends_on: condition: service_healthy`) instead of starting as soon as the containers are created.
> 
> This reduces local fullstack startup flakiness by ensuring the frontend comes up after backend APIs are ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d51a7a7c301e1bd1584915cae9fe539ede5b1cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->