### PR TITLE
Return 400 for missing report API query parameters

### DIFF
--- a/recon-report-service/src/main/java/com/idea/recon/utility/ControllerAdvice.java
+++ b/recon-report-service/src/main/java/com/idea/recon/utility/ControllerAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -27,6 +28,16 @@ public class ControllerAdvice {
 		ErrorInfo error = new ErrorInfo();
 		error.setErrorMessage(env.getProperty(exception.getMessage()));
 		error.setErrorCode(HttpStatus.BAD_REQUEST.value()); 
+		error.setTimestamp(LocalDateTime.now());
+		return new ResponseEntity<ErrorInfo>(error, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(value = MissingServletRequestParameterException.class)
+	public ResponseEntity<ErrorInfo> MissingServletRequestParameterExceptionHandler(MissingServletRequestParameterException exception) {
+		logger.error("MissingServletRequestParameterException");
+		ErrorInfo error = new ErrorInfo();
+		error.setErrorMessage(exception.getMessage());
+		error.setErrorCode(HttpStatus.BAD_REQUEST.value());
 		error.setTimestamp(LocalDateTime.now());
 		return new ResponseEntity<ErrorInfo>(error, HttpStatus.BAD_REQUEST);
 	}


### PR DESCRIPTION
## Summary
- Add a `@ExceptionHandler` for `MissingServletRequestParameterException` in report-service `ControllerAdvice`
- Missing required query parameters (e.g. `userId`, `week`) now return **400** with `ErrorInfo` instead of falling through to the generic **500** handler

## Test plan
- [ ] Call a report endpoint without a required query param and confirm **400** + message body
- [ ] Confirm existing `ReportException` / `MicroserviceException` behavior unchanged


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to API error mapping for validation-style failures; no auth, data, or business-logic changes.
> 
> **Overview**
> Report-service global exception handling now treats **missing required query parameters** as client errors instead of internal failures.
> 
> A new handler for `MissingServletRequestParameterException` in `ControllerAdvice` returns **400** with an `ErrorInfo` body (message from the framework, BAD_REQUEST code, timestamp), matching the style used for `ReportException`. Calls that omit params such as `userId` or `week` should no longer fall through to the generic **500** `Exception` handler.
> 
> Existing handlers for `ReportException` and `MicroserviceException` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6552614e560d87725b61d8a895d7755bde13c9b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->