### PR TITLE
feat(report-service): resilient inter-service HTTP

### DIFF
--- a/docs/adr/2026-06-03-inter-service-http-resilience.md
+++ b/docs/adr/2026-06-03-inter-service-http-resilience.md
@@ -1,0 +1,44 @@
+# ADR: Inter-service HTTP resilience (report-service)
+
+**Status:** Accepted  
+**Date:** 2026-06-03  
+**Context:** `recon-report-service` is the only service that calls peer services over HTTP (`user-service` for JWT/relationship verification, `email-service` for report-created notifications).
+
+## Problem
+
+Outbound calls used a default `RestTemplate` with no connect/read timeouts and no retry. A slow or briefly unavailable peer could block threads indefinitely or fail on the first transient network blip, which is weak for a portfolio-grade microservices story.
+
+## Decision
+
+1. Configure one shared `@LoadBalanced` `RestTemplate` with explicit connect and read timeouts via `RestTemplateBuilder`.
+2. Route calls through `InterServiceHttpClient` backed by a programmatic `RetryTemplate` (not `@Retryable`).
+3. Externalize timeout and retry settings under `recon.inter-service.http.*` in `application.properties`.
+
+## Retried failures (GET / idempotent reads only)
+
+- `ResourceAccessException` (connection refused, I/O errors, timeouts surfaced by the client)
+- `SocketTimeoutException` (when thrown as a retryable cause)
+- `HttpServerErrorException` (5xx responses from the peer)
+
+Up to **3 total attempts** (configurable) with **fixed backoff** defaulting to **300ms** between attempts.
+
+## Not retried
+
+- **4xx** (`HttpClientErrorException`) — not listed in `retryOn()`; includes auth (401/403), validation (400), and business-rule responses propagated from `user-service`
+- **POST `/email/report-created`** — side-effecting (sends email); **single attempt only** to avoid duplicate notifications without idempotency keys
+- Non-HTTP failures that are not in the retry policy
+
+## Out of scope
+
+- Circuit breakers, bulkheads, rate limiting
+- Idempotency keys for email
+- Migrating to `WebClient` or Resilience4j
+- Retrying POST or other mutating calls
+- Changes to `recon-email-service`’s unused `RestTemplate` bean
+- Eureka/registry health-based routing beyond existing `@LoadBalanced` behavior
+
+## Consequences
+
+- GET verification calls are more tolerant of brief outages and 5xx from core.
+- Email notification failures surface immediately; operators may need to retry at the business layer or re-trigger manually.
+- Slightly higher tail latency when retries occur (bounded by attempt count and backoff).

--- a/recon-report-service/pom.xml
+++ b/recon-report-service/pom.xml
@@ -60,6 +60,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/recon-report-service/src/main/java/com/idea/recon/ReconReportServiceApplication.java
+++ b/recon-report-service/src/main/java/com/idea/recon/ReconReportServiceApplication.java
@@ -1,13 +1,19 @@
 package com.idea.recon;
 
+import java.time.Duration;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 
+import com.idea.recon.config.InterServiceHttpProperties;
+
 @SpringBootApplication
+@EnableConfigurationProperties(InterServiceHttpProperties.class)
 public class ReconReportServiceApplication {
 
 	public static void main(String[] args) {
@@ -16,9 +22,11 @@ public class ReconReportServiceApplication {
 	
 	@Bean
 	@LoadBalanced
-	public RestTemplate restTemplate(RestTemplateBuilder builder) {
-	   // Do any additional configuration here
-	   return builder.build();
+	public RestTemplate restTemplate(RestTemplateBuilder builder, InterServiceHttpProperties httpProperties) {
+		return builder
+				.setConnectTimeout(Duration.ofMillis(httpProperties.getConnectTimeoutMs()))
+				.setReadTimeout(Duration.ofMillis(httpProperties.getReadTimeoutMs()))
+				.build();
 	}
 
 }

--- a/recon-report-service/src/main/java/com/idea/recon/client/InterServiceHttpClient.java
+++ b/recon-report-service/src/main/java/com/idea/recon/client/InterServiceHttpClient.java
@@ -1,0 +1,38 @@
+package com.idea.recon.client;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Outbound HTTP to peer services (user-service, email-service) with timeouts on the
+ * underlying {@link RestTemplate} and retry only for safe, idempotent GET calls.
+ */
+@Component
+public class InterServiceHttpClient {
+
+	private final RestTemplate restTemplate;
+	private final RetryTemplate retryTemplate;
+
+	public InterServiceHttpClient(
+			RestTemplate restTemplate,
+			@Qualifier("interServiceRetryTemplate") RetryTemplate interServiceRetryTemplate) {
+		this.restTemplate = restTemplate;
+		this.retryTemplate = interServiceRetryTemplate;
+	}
+
+	public <T> ResponseEntity<T> get(String url, HttpEntity<?> entity, Class<T> responseType) {
+		return retryTemplate.execute(context -> restTemplate.exchange(url, HttpMethod.GET, entity, responseType));
+	}
+
+	/**
+	 * POST and other side-effecting calls: single attempt only (no retry).
+	 */
+	public <T> ResponseEntity<T> postWithoutRetry(String url, HttpEntity<?> entity, Class<T> responseType) {
+		return restTemplate.exchange(url, HttpMethod.POST, entity, responseType);
+	}
+}

--- a/recon-report-service/src/main/java/com/idea/recon/config/InterServiceHttpConfig.java
+++ b/recon-report-service/src/main/java/com/idea/recon/config/InterServiceHttpConfig.java
@@ -1,0 +1,25 @@
+package com.idea.recon.config;
+
+import java.net.SocketTimeoutException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+@Configuration
+public class InterServiceHttpConfig {
+
+	@Bean
+	public RetryTemplate interServiceRetryTemplate(InterServiceHttpProperties properties) {
+		InterServiceHttpProperties.Retry retry = properties.getRetry();
+		return RetryTemplate.builder()
+				.maxAttempts(retry.getMaxAttempts())
+				.fixedBackoff(retry.getBackoffMs())
+				.retryOn(ResourceAccessException.class)
+				.retryOn(SocketTimeoutException.class)
+				.retryOn(HttpServerErrorException.class)
+				.build();
+	}
+}

--- a/recon-report-service/src/main/java/com/idea/recon/config/InterServiceHttpProperties.java
+++ b/recon-report-service/src/main/java/com/idea/recon/config/InterServiceHttpProperties.java
@@ -1,0 +1,57 @@
+package com.idea.recon.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "recon.inter-service.http")
+public class InterServiceHttpProperties {
+
+	private int connectTimeoutMs = 2000;
+	private int readTimeoutMs = 5000;
+	private Retry retry = new Retry();
+
+	public int getConnectTimeoutMs() {
+		return connectTimeoutMs;
+	}
+
+	public void setConnectTimeoutMs(int connectTimeoutMs) {
+		this.connectTimeoutMs = connectTimeoutMs;
+	}
+
+	public int getReadTimeoutMs() {
+		return readTimeoutMs;
+	}
+
+	public void setReadTimeoutMs(int readTimeoutMs) {
+		this.readTimeoutMs = readTimeoutMs;
+	}
+
+	public Retry getRetry() {
+		return retry;
+	}
+
+	public void setRetry(Retry retry) {
+		this.retry = retry;
+	}
+
+	public static class Retry {
+
+		private int maxAttempts = 3;
+		private long backoffMs = 300;
+
+		public int getMaxAttempts() {
+			return maxAttempts;
+		}
+
+		public void setMaxAttempts(int maxAttempts) {
+			this.maxAttempts = maxAttempts;
+		}
+
+		public long getBackoffMs() {
+			return backoffMs;
+		}
+
+		public void setBackoffMs(long backoffMs) {
+			this.backoffMs = backoffMs;
+		}
+	}
+}

--- a/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
+++ b/recon-report-service/src/main/java/com/idea/recon/service/impl/ReportServiceImpl.java
@@ -15,11 +15,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
+import com.idea.recon.client.InterServiceHttpClient;
 import com.idea.recon.dto.ContractorAndTraineeCorrespondenceDTO;
 import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.RelationshipVerificationDTO;
@@ -41,7 +40,7 @@ public class ReportServiceImpl implements ReportService {
 	private final org.slf4j.Logger logger = LoggerFactory.getLogger(this.getClass());
 	
 	@Autowired
-	RestTemplate restTemplate;
+	InterServiceHttpClient interServiceHttpClient;
 	
 	@Autowired
 	MicroserviceUtil microserviceUtil;
@@ -345,7 +344,7 @@ public class ReportServiceImpl implements ReportService {
 				"http://user-service/verify/school/contractor-to-trainee?by=" + contractorEmail + "&for=" + traineeEmail;
 		ResponseEntity<RelationshipVerificationDTO> response = null;
 		try {
-			response = restTemplate.exchange(url, HttpMethod.GET, entity, RelationshipVerificationDTO.class);
+			response = interServiceHttpClient.get(url, entity, RelationshipVerificationDTO.class);
 			logger.info("school verify: " + response.getBody());
 		} catch (Exception ex) {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
@@ -365,7 +364,7 @@ public class ReportServiceImpl implements ReportService {
 				"http://user-service/verify/trainee/contractor-to-trainee?by=" + contractorEmail + "&for=" + traineeEmail;
 		ResponseEntity<RelationshipVerificationDTO> response = null;
 		try {
-			response = restTemplate.exchange(url, HttpMethod.GET, entity, RelationshipVerificationDTO.class);
+			response = interServiceHttpClient.get(url, entity, RelationshipVerificationDTO.class);
 			logger.info("trainee verify: " + response.getBody());
 		} catch (Exception ex) {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
@@ -426,7 +425,7 @@ public class ReportServiceImpl implements ReportService {
 		String url = "http://user-service/verify/contractor-to-trainee?by=" + sentByEmail + "&for=" + sentForEmail;
 		ResponseEntity<RelationshipVerificationDTO> response = null; 
 		try {
-			response = restTemplate.exchange(url, HttpMethod.GET, entity, RelationshipVerificationDTO.class);
+			response = interServiceHttpClient.get(url, entity, RelationshipVerificationDTO.class);
 			logger.info("AFTER RESPONE: " + response.getBody().toString());
 		} catch (Exception ex) {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);
@@ -458,8 +457,7 @@ public class ReportServiceImpl implements ReportService {
 		HttpEntity<ContractorAndTraineeCorrespondenceDTO> entity = new HttpEntity<>(data, headers);
 
 		try {
-			response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
-			//restTemplate.postFor
+			response = interServiceHttpClient.postWithoutRetry(url, entity, String.class);
 			logger.info("AFTER RESPONE: " + response.getBody().toString());
 		} catch (Exception ex) {
 			microserviceUtil.handleHttpClientExceptionAndHttpServerException(ex);

--- a/recon-report-service/src/main/resources/application.properties
+++ b/recon-report-service/src/main/resources/application.properties
@@ -27,3 +27,9 @@ spring.datasource.password=root
 # Actuator
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
+
+# Inter-service HTTP (report-service -> user-service, email-service)
+recon.inter-service.http.connect-timeout-ms=2000
+recon.inter-service.http.read-timeout-ms=5000
+recon.inter-service.http.retry.max-attempts=3
+recon.inter-service.http.retry.backoff-ms=300

--- a/recon-report-service/src/test/java/com/idea/recon/client/InterServiceHttpClientTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/client/InterServiceHttpClientTest.java
@@ -1,0 +1,84 @@
+package com.idea.recon.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class InterServiceHttpClientTest {
+
+	@Mock
+	private RestTemplate restTemplate;
+
+	private InterServiceHttpClient client;
+
+	@BeforeEach
+	void setUp() {
+		RetryTemplate retryTemplate = RetryTemplate.builder()
+				.maxAttempts(3)
+				.fixedBackoff(200)
+				.retryOn(ResourceAccessException.class)
+				.retryOn(org.springframework.web.client.HttpServerErrorException.class)
+				.build();
+		client = new InterServiceHttpClient(restTemplate, retryTemplate);
+	}
+
+	@Test
+	void get_doesNotRetryOn4xx() {
+		when(restTemplate.exchange(eq("http://user-service/verify"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(String.class)))
+				.thenThrow(new HttpClientErrorException(HttpStatus.FORBIDDEN));
+
+		assertThrows(HttpClientErrorException.class,
+				() -> client.get("http://user-service/verify", HttpEntity.EMPTY, String.class));
+
+		verify(restTemplate, times(1)).exchange(eq("http://user-service/verify"), eq(HttpMethod.GET),
+				any(HttpEntity.class), eq(String.class));
+	}
+
+	@Test
+	void get_retriesResourceAccessExceptionThenSucceeds() {
+		when(restTemplate.exchange(eq("http://user-service/verify"), eq(HttpMethod.GET), any(HttpEntity.class),
+				eq(String.class)))
+				.thenThrow(new ResourceAccessException("connection reset"))
+				.thenReturn(ResponseEntity.ok("ok"));
+
+		ResponseEntity<String> response = client.get("http://user-service/verify", HttpEntity.EMPTY, String.class);
+
+		assertEquals("ok", response.getBody());
+		verify(restTemplate, times(2)).exchange(eq("http://user-service/verify"), eq(HttpMethod.GET),
+				any(HttpEntity.class), eq(String.class));
+	}
+
+	@Test
+	void post_doesNotRetryOnTransientFailure() {
+		when(restTemplate.exchange(eq("http://email-service/email/report-created"), eq(HttpMethod.POST),
+				any(HttpEntity.class), eq(String.class)))
+				.thenThrow(new ResourceAccessException("connection reset"));
+
+		assertThrows(ResourceAccessException.class,
+				() -> client.postWithoutRetry("http://email-service/email/report-created", HttpEntity.EMPTY,
+						String.class));
+
+		verify(restTemplate, times(1)).exchange(eq("http://email-service/email/report-created"),
+				eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+	}
+}

--- a/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
+++ b/recon-report-service/src/test/java/com/idea/recon/service/impl/ReportServiceImplTest.java
@@ -22,10 +22,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
 
+import com.idea.recon.client.InterServiceHttpClient;
 import com.idea.recon.dto.CreateRetortDTO;
 import com.idea.recon.dto.RelationshipVerificationDTO;
 import com.idea.recon.dto.ReportDTO;
@@ -41,7 +40,7 @@ import com.idea.recon.utility.MicroserviceUtil;
 class ReportServiceImplTest {
 
 	@Mock
-	private RestTemplate restTemplate;
+	private InterServiceHttpClient interServiceHttpClient;
 
 	@Mock
 	private MicroserviceUtil microserviceUtil;
@@ -76,7 +75,7 @@ class ReportServiceImplTest {
 				.weekEndDate(LocalDate.of(2026, 5, 10))
 				.build();
 
-		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+		when(interServiceHttpClient.get(contains("/verify/contractor-to-trainee"), any(HttpEntity.class),
 				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
 		when(reportRepository.contractorReportExist(eq(10), eq(20), eq(LocalDate.of(2026, 5, 4)),
 				eq(LocalDate.of(2026, 5, 10)))).thenReturn(false);
@@ -85,7 +84,7 @@ class ReportServiceImplTest {
 			report.setReportId(99);
 			return report;
 		});
-		when(restTemplate.exchange(contains("/email/report-created"), eq(HttpMethod.POST), any(HttpEntity.class),
+		when(interServiceHttpClient.postWithoutRetry(contains("/email/report-created"), any(HttpEntity.class),
 				eq(String.class))).thenReturn(ResponseEntity.ok("ok"));
 
 		String result = reportService.createReport(reportDTO, "token");
@@ -138,7 +137,7 @@ class ReportServiceImplTest {
 				.finalizedAt(null)
 				.build();
 
-		when(restTemplate.exchange(contains("/verify/contractor-to-trainee"), eq(HttpMethod.GET), any(HttpEntity.class),
+		when(interServiceHttpClient.get(contains("/verify/contractor-to-trainee"), any(HttpEntity.class),
 				eq(RelationshipVerificationDTO.class))).thenReturn(ResponseEntity.ok(relationship));
 		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))
 				.thenReturn(Optional.of(draft));
@@ -173,7 +172,7 @@ class ReportServiceImplTest {
 				.weekEndDate(weekEnd)
 				.build();
 
-		when(restTemplate.exchange(contains("/verify/trainee/contractor-to-trainee"), eq(HttpMethod.GET),
+		when(interServiceHttpClient.get(contains("/verify/trainee/contractor-to-trainee"),
 				any(HttpEntity.class), eq(RelationshipVerificationDTO.class)))
 				.thenReturn(ResponseEntity.ok(relationship));
 		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))
@@ -206,7 +205,7 @@ class ReportServiceImplTest {
 				.weekEndDate(weekEnd)
 				.build();
 
-		when(restTemplate.exchange(contains("/verify/trainee/contractor-to-trainee"), eq(HttpMethod.GET),
+		when(interServiceHttpClient.get(contains("/verify/trainee/contractor-to-trainee"),
 				any(HttpEntity.class), eq(RelationshipVerificationDTO.class)))
 				.thenReturn(ResponseEntity.ok(relationship));
 		when(reportRepository.getSpecificReport(eq(10), eq(20), eq(weekStart), eq(weekEnd)))


### PR DESCRIPTION
## Summary

- Add explicit connect/read timeouts on the shared `@LoadBalanced` `RestTemplate` (configurable via `recon.inter-service.http.*`).
- Route outbound calls through `InterServiceHttpClient` with a programmatic `RetryTemplate` for idempotent **GET** verification calls to `user-service`.
- **POST** `email/report-created` remains **single-attempt** (no retry) to avoid duplicate emails without idempotency keys.
- Document behavior in `docs/adr/2026-06-03-inter-service-http-resilience.md`.

**Retried:** `ResourceAccessException`, `SocketTimeoutException`, `HttpServerErrorException` (5xx), up to 3 attempts with 300ms backoff.

**Not retried:** 4xx (auth/validation/business), POST side effects.

## Test plan

- [x] `export JAVA_HOME=.../corretto-11.0.26` then `cd recon-report-service && mvn clean test` — **11 tests, BUILD SUCCESS**
- [x] `InterServiceHttpClientTest` — 4xx no retry, GET retries transient I/O, POST no retry
- [ ] Smoke: create report with stack up; verify user-service verify still works under normal conditions


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how report flows call user-service verification and email notification (retries on GET, no retry on POST); wrong retry policy could mask auth failures or duplicate emails if misconfigured, but scope is bounded and tested.
> 
> **Overview**
> **recon-report-service** now hardens outbound calls to **user-service** and **email-service** instead of using a bare `@LoadBalanced` `RestTemplate`.
> 
> The shared `RestTemplate` gets **connect/read timeouts** from `recon.inter-service.http.*` (defaults 2s / 5s). Outbound traffic goes through **`InterServiceHttpClient`**: **GET** verification calls use a programmatic **`RetryTemplate`** (up to 3 attempts, 300ms backoff) for transient I/O, timeouts, and **5xx**; **4xx** and **POST** `email/report-created` stay **single-attempt** to avoid duplicate emails. **`ReportServiceImpl`** is wired to the client; **`spring-retry`** is added; behavior is documented in an **ADR** and covered by **`InterServiceHttpClientTest`** plus updated service tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c232054b167476d858f577fae21e28a2744def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->