### PR TITLE
feat(gateway): add recon-gateway with Eureka routing and resilience

### DIFF
--- a/documentation/recon-gateway-integration.md
+++ b/documentation/recon-gateway-integration.md
@@ -1,0 +1,247 @@
+# Recon API Gateway Integration
+
+This document describes the introduction of `recon-gateway`, a Spring Cloud Gateway microservice, and the supporting changes in Eureka and recon-core (`reconV2`) that enable gateway routing, resilience patterns, and local development without Docker-only environment variables.
+
+**Branch:** `feature/recon-gateway-ms` → PR into `dockerized`
+
+---
+
+## Summary
+
+| Area | Change |
+|------|--------|
+| **New service** | `recon-gateway` — reactive API gateway with Eureka discovery, circuit breaker, retry, and request logging |
+| **Eureka** | Default port fallback when `APP_PORT` is unset (`8761`) |
+| **recon-core** | Local-dev env defaults, Lombok build fix, permissive test endpoints for gateway resilience experiments |
+| **Docker Compose** | Not updated in this PR — gateway runs standalone for now |
+
+---
+
+## New Service: `recon-gateway`
+
+### Purpose
+
+`recon-gateway` is the single HTTP entry point for routing client traffic to backend services registered in Eureka. It demonstrates:
+
+- **Service discovery routing** via `lb://USER-SERVICE`
+- **Circuit breaking** (Resilience4j) with a local fallback
+- **Retry** with exponential backoff for flaky downstream paths
+- **Per-route timeouts** overriding global HTTP client settings
+- **Structured request/response logging** via a global filter
+
+### Technology Stack
+
+| Component | Version |
+|-----------|---------|
+| Spring Boot | 3.0.5 |
+| Spring Cloud | 2022.0.5 |
+| Java | 17 |
+| Gateway | Spring Cloud Gateway (WebFlux) |
+| Resilience | `spring-cloud-starter-circuitbreaker-reactor-resilience4j` |
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `RouteLocatorConfig.java` | Defines routes, filters (strip prefix, circuit breaker, retry), and per-route timeouts |
+| `GatewayRequestLoggingFilter.java` | Global filter logging inbound/outbound requests with timing |
+| `FallbackController.java` | Returns `"Fallback"` when the recon-core circuit breaker opens |
+| `GatewayDiscoveryConfiguration.java` | Enables Eureka client (`@EnableDiscoveryClient`) |
+| `application.properties` | Port, Eureka URL, circuit breaker tuning, global HTTP timeouts |
+
+### Routes
+
+Gateway listens on port **8080** by default (`RECON_GATEWAY` env var).
+
+| Route ID | Path pattern | Backend | Filters |
+|----------|--------------|---------|---------|
+| `recon-core-ms` | `/api/recon/core/**` | `lb://USER-SERVICE` | Strip 3 path segments, circuit breaker → `/fallback` |
+| `recon-core-ms-retry` | `/api/recon/core/user/test/flaky/**` | `lb://USER-SERVICE` | Strip 3 path segments, retry (3x on 500, backoff) |
+| Demo routes | `/get`, `/gets`, `*.circuitbreaker.com` | `httpbin.org` | Learning/examples (can be removed later) |
+
+#### Path rewriting example
+
+A request to:
+
+```
+GET http://localhost:8080/api/recon/core/user/test
+```
+
+is stripped of `/api/recon/core` and forwarded to recon-core as:
+
+```
+GET http://user-service:4000/user/test
+```
+
+`USER-SERVICE` is the Eureka registration name for recon-core (`spring.application.name=user-service` in reconV2).
+
+### Resilience Configuration
+
+**Circuit breaker** (`recon-core-ms` instance):
+
+- COUNT_BASED sliding window, size 5
+- Opens at 50% failure rate after 5 calls
+- 10s wait in open state, 2 calls permitted in half-open
+- Time limiter: 10s
+
+**Global HTTP client** (gateway level):
+
+- Connect timeout: 1000ms (`RECON_GATEWAY_CONNECTION_TIMEOUT`)
+- Response timeout: 3s (`RECON_GATEWAY_SERVICE_RESPONSE_TIMEOUT`)
+
+**Per-route overrides** (recon-core routes):
+
+- Connect timeout: 10s
+- Response timeout: 5s
+
+> **Note:** Resilience4j TimeLimiter wraps the downstream call. The effective timeout hierarchy is documented in `application.properties` comments.
+
+### Running Locally
+
+Prerequisites: Eureka on 8761, recon-core on 4000 (both can use the new default env fallbacks).
+
+```bash
+# 1. Start Eureka
+cd recon-discovery-service && ./mvnw spring-boot:run
+
+# 2. Start recon-core (MySQL required for full app; test endpoints work without DB for basic checks)
+cd reconV2 && ./mvnw spring-boot:run
+
+# 3. Start gateway
+cd recon-gateway && ./mvnw spring-boot:run
+```
+
+Verify:
+
+```bash
+# Direct recon-core
+curl http://localhost:4000/user/test
+
+# Via gateway
+curl http://localhost:8080/api/recon/core/user/test
+
+# Circuit breaker fallback (after repeated failures to /user/test/internal-error)
+curl http://localhost:8080/api/recon/core/user/test/internal-error
+```
+
+Actuator endpoints: `health`, `info`, `gateway` (route inspection).
+
+---
+
+## Eureka Changes (`recon-discovery-service`)
+
+**File:** `src/main/resources/application.yml`
+
+```yaml
+server:
+  port: ${APP_PORT:8761}
+```
+
+**Why:** Allows running Eureka locally without setting `APP_PORT` in the environment. Docker Compose continues to set `APP_PORT` via `env/recon-eureka.env`, so container behavior is unchanged.
+
+---
+
+## recon-core Changes (`reconV2`)
+
+### Local development defaults
+
+**File:** `src/main/resources/application.properties`
+
+| Property | Before | After |
+|----------|--------|-------|
+| Eureka URL | `http://${EUREKA_SERVICE_NAME}:8761/eureka` | `http://${EUREKA_SERVICE_NAME:localhost}:8761/eureka` |
+| Server port | `${APP_PORT}` | `${APP_PORT:4000}` |
+| Config server | `http://${EUREKA_SERVICE_NAME}:8761` | `http://${EUREKA_SERVICE_NAME:localhost}:8761` |
+| MySQL URL | `jdbc:mysql://${MYSQL_SERVICE_NAME}:3306/recon` | `jdbc:mysql://${MYSQL_SERVICE_NAME:localhost}:3306/recon` |
+
+**Why:** recon-core can start outside Docker Compose with sensible localhost defaults, matching the gateway/Eureka local-dev workflow.
+
+### Security: test endpoint wildcard
+
+**File:** `SecurityConfig.java`
+
+```java
+.antMatchers(..., "/user/test/**", ...)
+```
+
+Previously only `/user/test` was permitted without authentication. Sub-paths used by gateway resilience experiments (`/user/test/internal-error`, `/user/test/flaky/{percent}`, etc.) now bypass JWT.
+
+### New test endpoints
+
+**File:** `JwtAuthenticationController.java`
+
+| Endpoint | Behavior |
+|----------|----------|
+| `GET /user/test/internal-error` | Returns 500 for the first 10 calls, then 200 — triggers circuit breaker |
+| `GET /user/test/variable-response/{seconds}` | Sleeps for `{seconds}` then returns 200 — timeout testing |
+| `GET /user/test/flaky/{percent}` | Random 500 based on `{percent}` threshold — retry testing |
+
+These are **development/resilience tooling**, not production API surface. Consider restricting or removing before production deployment.
+
+### Maven / Lombok build fix
+
+**File:** `pom.xml`
+
+- Removed duplicate `spring-boot-starter-web` dependency entries
+- Added explicit `maven-compiler-plugin` with Lombok annotation processor path (`lombok.version` 1.18.46)
+
+**Why:** Fixes Lombok annotation processing failures when building with newer JDKs / compiler plugin versions.
+
+---
+
+## Tests Added
+
+| Module | Test | Purpose |
+|--------|------|---------|
+| `recon-gateway` | `ReconApplicationTests` | Context loads (Eureka disabled in test profile) |
+| `recon-gateway` | `FallbackControllerTest` | `/fallback` returns `"Fallback"` |
+| `recon-gateway` | `RouteLocatorConfigTest` | recon-core routes exist and target `lb://USER-SERVICE` |
+
+Run gateway tests:
+
+```bash
+cd recon-gateway && ./mvnw test
+```
+
+Test profile (`application-test.properties`) disables Eureka registration so tests do not require a running discovery server.
+
+---
+
+## Out of Scope (Follow-up Work)
+
+These items were intentionally left for a separate PR to keep this change focused:
+
+1. **Docker Compose** — add `recon-gateway` service, `env/recon-gateway.env`, healthcheck, and `depends_on: eureka`
+2. **Gateway Dockerfile** — mirror pattern from `recon-discovery-service/Dockerfile`
+3. **Remove httpbin demo routes** — `/get`, `/gets`, `*.circuitbreaker.com` are learning placeholders
+4. **Client routing** — point `recon-client` API base URL through gateway instead of direct recon-core
+5. **Production hardening** — remove or protect `/user/test/**` endpoints; tune circuit breaker thresholds for production traffic
+
+---
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+    Client --> Gateway["recon-gateway :8080"]
+    Gateway --> Eureka["Eureka :8761"]
+    Gateway -->|"lb://USER-SERVICE\n/api/recon/core/**"| Core["recon-core :4000"]
+    Gateway -->|circuit open| Fallback["/fallback"]
+    Core --> Eureka
+    Core --> MySQL[(MySQL)]
+```
+
+---
+
+## Verification Checklist
+
+- [x] `recon-gateway` unit tests pass (`./mvnw test`)
+- [ ] Eureka starts on 8761 without `APP_PORT` set
+- [ ] recon-core starts on 4000 with localhost defaults (MySQL available)
+- [ ] `curl localhost:8080/api/recon/core/user/test` returns Hello World via gateway
+- [ ] Circuit breaker opens after repeated 500s to `/user/test/internal-error`
+- [ ] Retry route recovers from flaky `/user/test/flaky/{percent}` responses
+
+---
+
+*Last updated: June 2026 — branch `feature/recon-gateway-ms`*

--- a/recon-discovery-service/src/main/resources/application.yml
+++ b/recon-discovery-service/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${APP_PORT}
+  port: ${APP_PORT:8761}
   #port: 4000
   
 eureka:

--- a/recon-gateway/.gitattributes
+++ b/recon-gateway/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/recon-gateway/.gitignore
+++ b/recon-gateway/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/recon-gateway/.mvn/wrapper/maven-wrapper.properties
+++ b/recon-gateway/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/recon-gateway/mvnw
+++ b/recon-gateway/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/recon-gateway/mvnw.cmd
+++ b/recon-gateway/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/recon-gateway/pom.xml
+++ b/recon-gateway/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.0.5</version>
+		<relativePath/>
+	</parent>
+
+	<groupId>com.gateway</groupId>
+	<artifactId>recon-gateway</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>recon-gateway</name>
+	<description>API Gateway for Recon services</description>
+
+	<properties>
+		<java.version>17</java.version>
+		<spring-cloud.version>2022.0.5</spring-cloud.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-dependencies</artifactId>
+				<version>${spring-cloud.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<!-- Spring Cloud Gateway reactive/WebFlux gateway -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-gateway</artifactId>
+		</dependency>
+
+		<!-- Allows gateway to register with Eureka and route using lb://SERVICE-NAME -->
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
+
+		<!-- Health checks / actuator endpoints -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<!-- Normal Spring Boot test dependency -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/recon-gateway/src/main/java/com/gateway/recon/ReconGatewayApplication.java
+++ b/recon-gateway/src/main/java/com/gateway/recon/ReconGatewayApplication.java
@@ -1,0 +1,13 @@
+package com.gateway.recon;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReconGatewayApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ReconGatewayApplication.class, args);
+	}
+
+}

--- a/recon-gateway/src/main/java/com/gateway/recon/configs/GatewayDiscoveryConfiguration.java
+++ b/recon-gateway/src/main/java/com/gateway/recon/configs/GatewayDiscoveryConfiguration.java
@@ -1,0 +1,16 @@
+package com.gateway.recon.configs;
+
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableDiscoveryClient
+public class GatewayDiscoveryConfiguration {
+
+    /*@Bean
+    public DiscoveryClientRouteDefinitionLocator discoveryClientRouteLocator(ReactiveDiscoveryClient discoveryClient) {
+
+        return new DiscoveryClientRouteDefinitionLocator(discoveryClient);
+    }*/
+
+}

--- a/recon-gateway/src/main/java/com/gateway/recon/configs/GatewayRequestLoggingFilter.java
+++ b/recon-gateway/src/main/java/com/gateway/recon/configs/GatewayRequestLoggingFilter.java
@@ -1,0 +1,62 @@
+package com.gateway.recon.configs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.UUID;
+
+@Component
+public class GatewayRequestLoggingFilter implements GlobalFilter, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(GatewayRequestLoggingFilter.class);
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String requestId = UUID.randomUUID().toString().substring(0, 8);
+        long start = System.currentTimeMillis();
+
+        String method = exchange.getRequest().getMethod().toString();
+        URI originalUri = exchange.getRequest().getURI();
+
+        log.info("[GW:{}] IN  method={} uri={}", requestId, method, originalUri);
+
+        return chain.filter(exchange)
+                .doOnError(ex -> {
+                    log.warn("[GW:{}] ERROR type={} message={}",
+                            requestId,
+                            ex.getClass().getSimpleName(),
+                            ex.getMessage());
+                })
+                .doFinally(signalType -> {
+                    long durationMs = System.currentTimeMillis() - start;
+
+                    Route route = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR);
+                    URI routedUri = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR);
+                    Object status = exchange.getResponse().getStatusCode();
+
+                    String routeId = route != null ? route.getId() : "NO_ROUTE";
+
+                    log.info("[GW:{}] OUT route={} routedUri={} status={} durationMs={} signal={}",
+                            requestId,
+                            routeId,
+                            routedUri,
+                            status,
+                            durationMs,
+                            signalType);
+                });
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/recon-gateway/src/main/java/com/gateway/recon/configs/RouteLocatorConfig.java
+++ b/recon-gateway/src/main/java/com/gateway/recon/configs/RouteLocatorConfig.java
@@ -1,0 +1,68 @@
+package com.gateway.recon.configs;
+
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Configuration
+public class RouteLocatorConfig {
+
+    private static final String CONNECT_TIMEOUT_ATTR = "connect-timeout";
+    private static final String RESPONSE_TIMEOUT_ATTR = "response-timeout";
+
+    @Bean
+    public RouteLocator myRoutes(RouteLocatorBuilder builder) {
+        return builder.routes()
+                .route(p -> p
+                        .path("/get")
+                        .filters(f -> f.addRequestHeader("Hello", "World"))
+                        .uri("http://httpbin.org:80"))
+                .route(p -> p
+                        .host("*.circuitbreaker.com")
+                        .filters(f -> f.circuitBreaker(config -> config.setName("mycmd")))
+                        .uri("http://httpbin.org:80"))
+                .route("recon-core-ms-retry", p -> p
+                        .path("/api/recon/core/user/test/flaky/**")
+                        .filters(f ->
+                                f.stripPrefix(3)
+                                    .retry(rc -> rc
+                                            .setRetries(3)
+                                            .setStatuses(HttpStatus.INTERNAL_SERVER_ERROR)
+                                            .setMethods(HttpMethod.GET)
+                                            .setBackoff(Duration.ofMillis(100), Duration.ofSeconds(1), 2, false)
+                                    )
+                        )
+                        .metadata(CONNECT_TIMEOUT_ATTR, 10000) // overrides global set at propertise level
+                        .metadata(RESPONSE_TIMEOUT_ATTR, 5000) // overrides global set at propertise level
+                        .uri("lb://USER-SERVICE")
+
+                )
+                .route("recon-core-ms", p -> p
+                        .path("/api/recon/core/**")
+                        .filters(f ->
+                                f.stripPrefix(3)
+                                .circuitBreaker(config ->
+                                        config
+                                            .setName("recon-core-ms")
+                                            .addStatusCode("INTERNAL_SERVER_ERROR")
+                                            .setFallbackUri("forward:/fallback")
+                                )
+                        )
+                        .metadata(CONNECT_TIMEOUT_ATTR, 10000) // overrides global set at propertise level
+                        .metadata(RESPONSE_TIMEOUT_ATTR, 5000) // overrides global set at propertise level
+                        .uri("lb://USER-SERVICE")
+
+                )
+                .route(p -> p
+                        .path("/gets")
+                        .filters(f -> f.addRequestHeader("Hello", "World"))
+                        .uri("http://httpbin.org:80"))
+                .build();
+    }
+}

--- a/recon-gateway/src/main/java/com/gateway/recon/controller/FallbackController.java
+++ b/recon-gateway/src/main/java/com/gateway/recon/controller/FallbackController.java
@@ -1,0 +1,14 @@
+package com.gateway.recon.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FallbackController {
+
+    @GetMapping("/fallback")
+    public String fallback() {
+        return "Fallback";
+    }
+
+}

--- a/recon-gateway/src/main/resources/application.properties
+++ b/recon-gateway/src/main/resources/application.properties
@@ -1,0 +1,40 @@
+spring.application.name=recon
+server.port=${RECON_GATEWAY:8080}
+
+eureka.client.service-url.defaultZone=http://${EUREKA_SERVICE_NAME:localhost}:8761/eureka
+
+# Gateway route matching, predicates, filters
+#logging.level.org.springframework.cloud.gateway=DEBUG
+
+# WebFlux request handling
+#logging.level.org.springframework.web.reactive=DEBUG
+#logging.level.org.springframework.http.server.reactive=DEBUG
+
+# Reactor Netty client/server behavior
+#logging.level.reactor.netty=DEBUG
+
+# Show route actuator endpoint
+management.endpoint.gateway.enabled=true
+management.endpoints.web.exposure.include=health,info,gateway
+
+# Circuit breaker settings - for Recon Core learning purposes. set lower so I can trigger circuit breaker manually to open state and get fail fast rejections
+resilience4j.circuitbreaker.instances.recon-core-ms.sliding-window-type=COUNT_BASED
+resilience4j.circuitbreaker.instances.recon-core-ms.sliding-window-size=5
+resilience4j.circuitbreaker.instances.recon-core-ms.minimum-number-of-calls=5
+resilience4j.circuitbreaker.instances.recon-core-ms.failure-rate-threshold=50
+resilience4j.circuitbreaker.instances.recon-core-ms.wait-duration-in-open-state=10s
+resilience4j.circuitbreaker.instances.recon-core-ms.permitted-number-of-calls-in-half-open-state=2
+
+resilience4j.timelimiter.instances.recon-core-ms.timeout-duration=10s
+
+# Gateway timeout
+# NOTE: hiearchy -> TimeLImter (circuit breaker) [wraps call] -> response timeout [inside TimeLimiter and failure counts toward TimeLimiter fail count]
+# Resilience4j TimeLimiter: 2s (circuit breaker timeout) will effectively beat out connection timeout
+# TimeLimiter = "How long will I allow the whole protected call to run?"
+# Gateway global response timeout: 3s
+# connect-timeout = "How long will I wait to establish a network connection?"
+# Gateway route response timeout: 10s
+# response-timeout = "How long will Gateway HTTP client wait for backend response?"
+spring.cloud.gateway.httpclient.connect-timeout: ${RECON_GATEWAY_CONNECTION_TIMEOUT:1000}
+spring.cloud.gateway.httpclient.response-timeout: ${RECON_GATEWAY_SERVICE_RESPONSE_TIMEOUT:3s}
+

--- a/recon-gateway/src/test/java/com/gateway/recon/ReconApplicationTests.java
+++ b/recon-gateway/src/test/java/com/gateway/recon/ReconApplicationTests.java
@@ -1,0 +1,14 @@
+package com.gateway.recon;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@org.springframework.test.context.ActiveProfiles("test")
+class ReconApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/recon-gateway/src/test/java/com/gateway/recon/configs/RouteLocatorConfigTest.java
+++ b/recon-gateway/src/test/java/com/gateway/recon/configs/RouteLocatorConfigTest.java
@@ -1,0 +1,41 @@
+package com.gateway.recon.configs;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RouteLocatorConfigTest {
+
+    @Autowired
+    private RouteLocator routeLocator;
+
+    @Test
+    void definesReconCoreRoutes() {
+        List<Route> routes = routeLocator.getRoutes().collectList().block();
+
+        assertThat(routes)
+                .extracting(Route::getId)
+                .contains("recon-core-ms", "recon-core-ms-retry");
+    }
+
+    @Test
+    void reconCoreRouteTargetsUserService() {
+        List<Route> routes = routeLocator.getRoutes().collectList().block();
+
+        Route reconCoreRoute = routes.stream()
+                .filter(route -> "recon-core-ms".equals(route.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(reconCoreRoute.getUri().toString()).isEqualTo("lb://USER-SERVICE");
+    }
+}

--- a/recon-gateway/src/test/java/com/gateway/recon/controller/FallbackControllerTest.java
+++ b/recon-gateway/src/test/java/com/gateway/recon/controller/FallbackControllerTest.java
@@ -1,0 +1,27 @@
+package com.gateway.recon.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles("test")
+class FallbackControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void fallbackReturnsFallbackMessage() {
+        webTestClient.get()
+                .uri("/fallback")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .isEqualTo("Fallback");
+    }
+}

--- a/recon-gateway/src/test/resources/application-test.properties
+++ b/recon-gateway/src/test/resources/application-test.properties
@@ -1,0 +1,3 @@
+# Keep gateway tests independent of a running Eureka server.
+eureka.client.enabled=false
+spring.cloud.discovery.enabled=false

--- a/reconV2/pom.xml
+++ b/reconV2/pom.xml
@@ -15,6 +15,7 @@
     <description>recon app</description>
     <properties>
         <java.version>11</java.version>
+        <lombok.version>1.18.46</lombok.version>
         <log4j2.version>2.17.1</log4j2.version>
         <spring-cloud.version>2021.0.6</spring-cloud.version>
     </properties>
@@ -70,15 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
         <dependency>
@@ -86,11 +79,11 @@
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <dependency>
+        <!--<dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -135,6 +128,21 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${java.version}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/reconV2/src/main/java/com/idea/recon/config/SecurityConfig.java
+++ b/reconV2/src/main/java/com/idea/recon/config/SecurityConfig.java
@@ -152,7 +152,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		// We don't need CSRF for this example
 		httpSecurity.cors().and().csrf().disable()
 				// dont authenticate this particular request
-				.authorizeRequests().antMatchers("/actuator/**", "/user/authenticate/**", "/register", "/user/test", "/refresh/**", "/bucket/**", "/trainee/unregistered", "/contractor/unregistered-to-school").permitAll()
+				.authorizeRequests().antMatchers("/actuator/**", "/user/authenticate/**", "/register", "/user/test/**", "/refresh/**", "/bucket/**", "/trainee/unregistered", "/contractor/unregistered-to-school").permitAll()
 				
 				// all other requests need to be authenticated
 					.anyRequest().authenticated().and()

--- a/reconV2/src/main/java/com/idea/recon/controllers/JwtAuthenticationController.java
+++ b/reconV2/src/main/java/com/idea/recon/controllers/JwtAuthenticationController.java
@@ -74,9 +74,37 @@ public class JwtAuthenticationController {
 	
 	@Autowired
 	private AmazonS3 s3Client;
+
+	int errorCount=0;
 	
 	@GetMapping(value="/test", produces="application/json")
 	public ResponseEntity<String> helloWorld() {
+		return new ResponseEntity<>("Hello World!", HttpStatus.OK);
+	}
+
+	@GetMapping(value="/test/internal-error", produces="application/json")
+	public ResponseEntity<String> helloInternalError() {
+		if (errorCount<10) {
+			++errorCount;
+			return new ResponseEntity<>("Hello World!", HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+		return new ResponseEntity<>("Hello World!", HttpStatus.OK);
+	}
+
+	@GetMapping(value="/test/variable-response/{seconds}", produces="application/json")
+	public ResponseEntity<String> helloResponseTime(@PathVariable int seconds) throws InterruptedException {
+		seconds = Math.abs(seconds);
+		int sleepMs = seconds*1000;
+		Thread.sleep(sleepMs);
+		return new ResponseEntity<>("Hello World, I slept for "+seconds+" seconds", HttpStatus.OK);
+	}
+
+	@GetMapping(value="/test/flaky/{perecent}", produces="application/json")
+	public ResponseEntity<String> helloRandomSuccess(@PathVariable int perecent){
+		int rand = (int)(Math.random()*100);
+		logger.info("Flaky test: returning" + (rand > perecent ? " OK" : " Internal Server Error"));
+		if (rand < perecent)
+			return new ResponseEntity<>("Hello World!", HttpStatus.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>("Hello World!", HttpStatus.OK);
 	}
 

--- a/reconV2/src/main/resources/application.properties
+++ b/reconV2/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 #Eureka Server Invo
 #eureka.client.service-url.defaultZone=http://localhost:8761/eureka 
-eureka.client.service-url.defaultZone=http://${EUREKA_SERVICE_NAME}:8761/eureka 
+eureka.client.service-url.defaultZone=http://${EUREKA_SERVICE_NAME:localhost}:8761/eureka 
 
 #Clint info
-server.port=${APP_PORT}
-spring.config.import=optional:configserver:http://${EUREKA_SERVICE_NAME}:8761
+server.port=${APP_PORT:4000}
+spring.config.import=optional:configserver:http://${EUREKA_SERVICE_NAME:localhost}:8761
 spring.application.name=user-service
 
 # JWT INFORMATION 
@@ -49,7 +49,7 @@ spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 #spring.datasource.url=jdbc:mysql://database-1.chwwf3hktlmf.us-east-2.rds.amazonaws.com:3306/recon
 # LOCAL SQL
 #spring.datasource.url=jdbc:mysql://localhost:3306/recon
-spring.datasource.url=jdbc:mysql://${MYSQL_SERVICE_NAME}:3306/recon
+spring.datasource.url=jdbc:mysql://${MYSQL_SERVICE_NAME:localhost}:3306/recon
 spring.datasource.username=root
 spring.datasource.password=root
 


### PR DESCRIPTION
## Summary

- Add new `recon-gateway` Spring Cloud Gateway service with Eureka discovery routing to recon-core (`lb://USER-SERVICE`), circuit breaker fallback, retry for flaky paths, and request logging
- Update Eureka and recon-core with localhost env defaults so services can run outside Docker Compose
- Add recon-core `/user/test/**` endpoints and security permits for gateway resilience experiments
- Add `documentation/recon-gateway-integration.md` covering architecture, routes, config, and follow-up work (Docker Compose integration)

## Test plan

- [x] `cd recon-gateway && ./mvnw test` — 4 tests pass (context, routes, fallback)
- [ ] Start Eureka, recon-core, and gateway locally; verify `curl localhost:8080/api/recon/core/user/test`
- [ ] Trigger circuit breaker via `/user/test/internal-error` and confirm `/fallback` response
- [ ] Verify flaky retry route at `/api/recon/core/user/test/flaky/{percent}`


Made with [Cursor](https://cursor.com)